### PR TITLE
Adding exception handling to backoff decorator for ConnectionReset Er…

### DIFF
--- a/tap_activecampaign/client.py
+++ b/tap_activecampaign/client.py
@@ -130,7 +130,7 @@ class ActiveCampaignClient(object):
 
 
     @backoff.on_exception(backoff.expo,
-                          (Server5xxError, ConnectionError, Server429Error),
+                          (Server5xxError, ConnectionError, Server429Error, OSError),
                           max_tries=5,
                           factor=2)
     # Rate limit: https://developers.activecampaign.com/reference#rate-limits


### PR DESCRIPTION
# Description of change
Tap was failing with `ConnectionResetError`. It appears this is a type of `OSError`. This error was added to the list of exceptions in the backoff decorator. Apparently this error can happen when making many requests to the same endpoint in a loop (as is the case here). It's hard to recreate this error given the small sample size of our test data set but was able to manually test that this would work when encountering this error.

# Manual QA steps
 - As mentioned, recreating this error is difficult. I manually tested this by simulating the error using the following code:
 
```
import socket

import backoff
import requests

URL = "https://google.com"


@backoff.on_exception(backoff.expo, (OSError))
def request(url):
    with requests.Session() as session:
        response = session.request("GET", url)
        print(f"response code: {response.status_code}")

        raise socket.error(104, 'Connection reset by peer')


def main():
    request(URL)


if __name__ == '__main__':
    main()

```
 
This code behaves as expected with backoff retrying the request multiple times.

# Risks
 - It may cause backoff to retry in the event of a different type of `OSError` that may not be recoverable.
 
# Rollback steps
 - revert this branch
