### PR TITLE
Fix data duplication issue

### DIFF
--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -585,8 +585,8 @@ STREAMS = {
       'data_key': 'ecomOrderActivities',
       'key_properties': ['id'],
       'replication_method': 'INCREMENTAL',
-      'replication_keys': ['updated_timestamp'],
-      'created_timestamp': 'created_timestamp',
+      'replication_keys': ['updated_date'],
+      'created_timestamp': 'created_date',
       'links': []
     },
 

--- a/tap_activecampaign/sync.py
+++ b/tap_activecampaign/sync.py
@@ -98,7 +98,7 @@ def process_records(catalog, #pylint: disable=too-many-branches
                     bookmark_dttm = transform_datetime(transformed_record[bookmark_field])
                     # Keep only records whose bookmark is after the last_datetime
                     if bookmark_dttm:
-                        if bookmark_dttm >= last_dttm:
+                        if bookmark_dttm > last_dttm:
                             write_record(stream_name, transformed_record, \
                                 time_extracted=time_extracted)
                             counter.increment()


### PR DESCRIPTION
# Description of change
- Fixing issue that was causing duplication of records to be emitted and updated stream with correct replication key and created at timestamp. Before writing records, the tap was comparing the current bookmark datetime to the datetime from the state file but it was doing a ">=" comparison. This was causing records from the previous run to be emitted again. Check was corrected to only emit records with a timestamp greater than the previous run. Additionally, one of the streams was using the incorrect fields for both the replication key and the created at timestamp field.

# Manual QA steps
- Run the tap once and produce a state file. Run again with state file and ensure that there are 0 records emitted for streams using "incremental" method.
 
# Risks
 - N/A 
 
# Rollback steps
 - revert this branch
