### PR TITLE
Bump to v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.1
+  * Bump to v0.1.1 to avoid PyPi file name reuse
+
 ## 0.1.0
   * Refactor code to class based [#8](https://github.com/singer-io/tap-activecampaign/pull/8)
   * Update all schemas [#10](https://github.com/singer-io/tap-activecampaign/pull/10)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-activecampaign',
-      version='0.1.0',
+      version='0.1.1',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Bump to v0.1.1 to avoid PyPi file name reuse

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
