### PR TITLE
Children speed improvements

### DIFF
--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -504,6 +504,7 @@ class Contacts(ActiveCampaign):
     created_timestamp = 'created_timestamp'
     bookmark_query_field = 'filters[updated_after]'
     links = ['contactGoals', 'contactLogs', 'geoIps', 'trackingLogs']
+    children= ['contact_custom_field_values', 'contact_automations']
 
 class ContactAutomations(ActiveCampaign):
     """
@@ -512,9 +513,10 @@ class ContactAutomations(ActiveCampaign):
     """
     stream_name = 'contact_automations'
     replication_keys = ['lastdate']
-    path = 'contactAutomations'
     data_key = 'contactAutomations'
     created_timestamp = 'adddate'
+    path = 'contacts/{}/contactAutomations'
+    parent = 'contacts'
 
 class ContactCustomFields(ActiveCampaign):
     """
@@ -556,6 +558,8 @@ class ContactCustomFieldValues(ActiveCampaign):
     path = 'fieldValues'
     data_key = 'fieldValues'
     created_timestamp = 'cdate'
+    path = 'contacts/{}/fieldValues'
+    parent = 'contacts'
 
 class ContactDeals(ActiveCampaign):
     """

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -555,7 +555,6 @@ class ContactCustomFieldValues(ActiveCampaign):
     """
     stream_name = 'contact_custom_field_values'
     replication_keys = ['udate']
-    path = 'fieldValues'
     data_key = 'fieldValues'
     created_timestamp = 'cdate'
     path = 'contacts/{}/fieldValues'


### PR DESCRIPTION
# Description of change
Suggested changes to improve sync speed on subsequent runs.
On each run, the amount of contacts field values or contact field automations synchronised it's always same and bookmarks aren't used. With this change the amount synchronised is based on how many contacts were updated since previous run.

# Manual QA steps
 - Executed successful run with and saved state
 - Updated a sample set of contacts custom fields
 - Verified that fields for only the sample set of contacts were synchronised. 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
