### PR TITLE
TDL-18032: Fix the transformation error of forms stream

### DIFF
--- a/tap_activecampaign/schemas/forms.json
+++ b/tap_activecampaign/schemas/forms.json
@@ -233,7 +233,7 @@
         {
           "type": "array",
           "items": {
-            "type": ["null", "object"],
+            "type": ["null", "object", "string"],
             "additionalProperties": true,
             "properties": {
               "id": {}


### PR DESCRIPTION
# Description of change
[TDL-18032](https://jira.talendforge.org/browse/TDL-18032): Fix transformation error.

- Currently, the schema of the recent field is like below so it expects an array of objects but the customer is getting an array of strings also so it throws an error.
- Added string also in the array part of the schema for the recent field.

# Manual QA steps
 - The mocked API call to return data as same as customer's record and verified that no transformation error there and data emitted successfully.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
