### PR TITLE
TDL-18288: Add `after` param for activities stream

### DIFF
--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -852,6 +852,7 @@ class Activities(ActiveCampaign):
     path = 'activities'
     data_key = 'activities'
     bookmark_query_field = 'after'
+    params = {'orders[tstamp]': 'asc'}
 
 class AutomationBlocks(ActiveCampaign):
     """

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -852,7 +852,6 @@ class Activities(ActiveCampaign):
     path = 'activities'
     data_key = 'activities'
     bookmark_query_field = 'after'
-    # params = {'orders[tstamp]': 'asc'}
 
 class AutomationBlocks(ActiveCampaign):
     """

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -852,7 +852,7 @@ class Activities(ActiveCampaign):
     path = 'activities'
     data_key = 'activities'
     bookmark_query_field = 'after'
-    params = {'orders[tstamp]': 'asc'}
+    # params = {'orders[tstamp]': 'asc'}
 
 class AutomationBlocks(ActiveCampaign):
     """

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -851,6 +851,7 @@ class Activities(ActiveCampaign):
     replication_keys = ['tstamp']
     path = 'activities'
     data_key = 'activities'
+    bookmark_query_field = 'after'
 
 class AutomationBlocks(ActiveCampaign):
     """

--- a/tests/unittests/test_params_for_activities_stream.py
+++ b/tests/unittests/test_params_for_activities_stream.py
@@ -1,0 +1,67 @@
+import requests
+from tap_activecampaign.streams import Activities
+from tap_activecampaign.client import ActiveCampaignClient
+import unittest
+from unittest import mock
+
+# mocked response class
+class Mockresponse:
+    def __init__(self, status_code, json, raise_error, headers=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+        self.headers = headers
+
+    def raise_for_status(self):
+        """
+            Raise error if 'raise_error' is True
+        """
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        """
+            Return mocked response
+        """
+        return self.text
+
+# function to get mocked response
+def get_response(status_code, json={}, raise_error=False, headers=None):
+    return Mockresponse(status_code, json, raise_error, headers)
+
+class TestActivitiesStreamParams(unittest.TestCase):
+    """
+        Test case to verify the params `after` and `orders` is set as expected for activities during API call
+    """
+
+    @mock.patch('requests.Session.request')
+    @mock.patch('tap_activecampaign.streams.Activities.process_records')
+    def test_activities_stream_params(self, mocked_process_records, mocked_request):
+        # mock request and return value
+        mocked_request.return_value = get_response(200, {
+            "activities": [],
+            "meta": {
+                "total": "0"
+            }
+        })
+        # mock 'process_records' and return value
+        mocked_process_records.return_value = "2022-04-01", 0
+
+        # create client
+        client = ActiveCampaignClient("test_client_id", "test_client_secret", "test_refresh_token")
+        # create 'Activities' stream object
+        activities = Activities(client=client)
+        # function call
+        activities.sync(client, {}, {}, "2022-04-01", activities.path, ["activities"])
+
+        # get arguments passed during calling "requests.Session.request"
+        args, kwargs = mocked_request.call_args
+        # get 'params' value from passed arguments
+        params = kwargs.get("params")
+
+        # verify the 'after' param is used with start date
+        self.assertTrue('after=2022-04-01' in params)
+        # verify the 'orders' param is used
+        self.assertTrue('orders[tstamp]=asc' in params)

--- a/tests/unittests/test_params_for_activities_stream.py
+++ b/tests/unittests/test_params_for_activities_stream.py
@@ -32,13 +32,13 @@ def get_response(status_code, json={}, raise_error=False, headers=None):
     return Mockresponse(status_code, json, raise_error, headers)
 
 class TestActivitiesStreamParams(unittest.TestCase):
-    """
-        Test case to verify the param `after` is set as expected for activities during API call
-    """
 
     @mock.patch('requests.Session.request')
     @mock.patch('tap_activecampaign.streams.Activities.process_records')
     def test_activities_stream_params(self, mocked_process_records, mocked_request):
+        """
+            Test case to verify the param `after` is set as expected for activities during API call
+        """
         # mock request and return value
         mocked_request.return_value = get_response(200, {
             "activities": [],

--- a/tests/unittests/test_params_for_activities_stream.py
+++ b/tests/unittests/test_params_for_activities_stream.py
@@ -33,7 +33,7 @@ def get_response(status_code, json={}, raise_error=False, headers=None):
 
 class TestActivitiesStreamParams(unittest.TestCase):
     """
-        Test case to verify the params `after` and `orders` is set as expected for activities during API call
+        Test case to verify the param `after` is set as expected for activities during API call
     """
 
     @mock.patch('requests.Session.request')
@@ -63,5 +63,3 @@ class TestActivitiesStreamParams(unittest.TestCase):
 
         # verify the 'after' param is used with start date
         self.assertTrue('after=2022-04-01' in params)
-        # verify the 'orders' param is used
-        self.assertTrue('orders[tstamp]=asc' in params)


### PR DESCRIPTION
# Description of change
TDL-18288: Add `after` param for activities stream
- Added `after` param for **activities** stream
- Added `orders` param to sort the response in ascending order of **tstamp**

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
