### PR TITLE
Add phone to list of supported fields

### DIFF
--- a/tap_activecampaign/schemas/contacts.json
+++ b/tap_activecampaign/schemas/contacts.json
@@ -8,6 +8,9 @@
     },
     "email": {
       "type": ["null", "string"]
+    },    
+    "phone": {
+      "type": ["null", "string"]
     },
     "first_name": {
       "type": ["null", "string"]


### PR DESCRIPTION
Maybe an oversight of schema changes in #14 ? We're evaluating Stitchdata specifically because of the ability to import Activecampaign and it looks like it mostly does the trick but missed this?

It's not clear to me if other changes are required to make this work.