### PR TITLE
Add string type for forms style.button.padding

### DIFF
--- a/tap_activecampaign/schemas/forms.json
+++ b/tap_activecampaign/schemas/forms.json
@@ -114,7 +114,7 @@
           "additionalProperties": false,
           "properties": {
             "padding": {
-              "type": ["null", "integer"]
+              "type": ["null", "integer", "string"]
             },
             "background": {
               "type": ["null", "string"]


### PR DESCRIPTION
# Description of change

- This is similar to #22
- Currently, the schema of the style.padding field expects an array of integers (e.g. `20` for 20px padding)
- However, we received API response with `"20px"` or `"20"`
- Added string also in the array part of the schema

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
