### PR TITLE
[TDL-22316] : Handle ChunkEncodingError & JSONDecodeError

### DIFF
--- a/tap_activecampaign/client.py
+++ b/tap_activecampaign/client.py
@@ -235,7 +235,11 @@ class ActiveCampaignClient(object):
         except Exception as err:
             LOGGER.error('{}'.format(err))
             LOGGER.error('response content: {}'.format(response.content))
-            raise Exception(err)
+            if response.content != b"":
+                raise Exception(err)
+
+            # Handling empty response b'' given by ActiveCampaign APIs
+            response_json = {}
 
         return response_json
 

--- a/tap_activecampaign/client.py
+++ b/tap_activecampaign/client.py
@@ -87,6 +87,8 @@ def should_retry_error(exception):
         # Tap raises Exception: ConnectionResetError(104, 'Connection reset by peer'). That's why we are retrying this error also.
         # Reference: https://app.circleci.com/pipelines/github/singer-io/tap-activecampaign/554/workflows/d448258e-20df-4e66-b2aa-bc8bd1f08912/jobs/558
         return True
+    elif type(exception) == ConnectionResetError:
+        return True
     else:
         return False
 
@@ -236,7 +238,7 @@ class ActiveCampaignClient(object):
             LOGGER.error('{}'.format(err))
             LOGGER.error('response content: {}'.format(response.content))
             if response.content != b"":
-                raise Exception(err)
+                raise err
 
             # Handling empty response b'' given by ActiveCampaign APIs
             response_json = {}

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -187,6 +187,21 @@ class TestActiveCampaignErrorhandlingForRequestMethod(unittest.TestCase):
         self.assertEqual(str(e.exception), expected_error_message)
 
 
+    @patch("time.sleep")
+    @patch("tap_activecampaign.client.ActiveCampaignClient.check_api_token")
+    @patch("requests.Session.request", return_value=Mockresponse("", 200, content=b""))
+    def test_request_with_handling_for_empty_content(self, mocked_request, mock_api_token, mock_sleep):
+        """
+        Test that `request` method gives empty json `{}` response when content is empty for a 200 response.
+        """
+        _client = client.ActiveCampaignClient('dummy_url', 'dummy_token')
+
+        response = _client.request("base_url")
+
+        # Verifying the empty response
+        self.assertEqual({}, response)
+
+
 class TestActiveCampaignErrorhandlingForCheckApiTokenMethod(unittest.TestCase):
 
     @patch("requests.Session.get", side_effect=mock_send_400)

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -413,6 +413,19 @@ class TestActiveCampaignErrorhandlingBackoff(unittest.TestCase):
         # Verify that requests.Session.get called 5 times
         self.assertEqual(mocked_request.call_count, 5)
 
+    @patch("requests.Session.get", side_effect=ConnectionResetError(104, 'Connection reset by peer'))
+    def test_enter_method_handle_connection_reset_error(self, mocked_request, mock_sleep):
+        """
+        Test that `__enter__` method retry ConnectionResetError(104) with Exception 5 times.
+        """
+        _client = client.ActiveCampaignClient('dummy_url', 'dummy_token')
+
+        with self.assertRaises(ConnectionResetError) as e:
+            _client.__enter__()
+
+        # Verify that requests.Session.get called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
+
     @patch("tap_activecampaign.client.ActiveCampaignClient.check_api_token")    
     @patch("requests.Session.request", side_effect=mock_send_429)
     def test_request_method_handle_429_exception(self, mocked_request, mock_api_token, mock_sleep):
@@ -506,6 +519,20 @@ class TestActiveCampaignErrorhandlingBackoff(unittest.TestCase):
         _client = client.ActiveCampaignClient('dummy_url', 'dummy_token')
     
         with self.assertRaises(Exception) as e:
+            _client.request("base_url")
+
+        # Verify that requests.Session.request called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
+
+    @patch("tap_activecampaign.client.ActiveCampaignClient.check_api_token")
+    @patch("requests.Session.request", side_effect=ConnectionResetError(104, 'Connection reset by peer'))
+    def test_request_method_handle_connection_reset_error(self, mocked_request, mock_api_token, mock_sleep):
+        """
+        Test that `request` method retry ConnectionResetError(104) with Exception 5 times.
+        """
+        _client = client.ActiveCampaignClient('dummy_url', 'dummy_token')
+
+        with self.assertRaises(ConnectionResetError) as e:
             _client.request("base_url")
 
         # Verify that requests.Session.request called 5 times


### PR DESCRIPTION
# Description of change
After referring to customer logs : 
```
2023-03-20 03:50:33,745Z    tap - INFO HTTP request to "contact_custom_field_values" endpoint took 2.339s, returned status code 200
2023-03-20 03:50:33,746Z    tap - ERROR ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
2023-03-20 03:50:33,746Z    tap - ERROR response content: b''
2023-03-20 03:50:33,747Z    tap - CRITICAL 'ChunkedEncodingError' object is not subscriptable
2023-03-20 03:50:33,747Z    tap - Traceback (most recent call last):
2023-03-20 03:50:33,747Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/urllib3/response.py", line 436, in _error_catcher
2023-03-20 03:50:33,747Z    tap -     yield
2023-03-20 03:50:33,747Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/urllib3/response.py", line 763, in read_chunked
2023-03-20 03:50:33,747Z    tap -     self._update_chunk_length()
2023-03-20 03:50:33,747Z    tap -   File "/code/orchestrator/tap-env/lib/python3.9/site-packages/urllib3/response.py", line 693, in _update_chunk_length
2023-03-20 03:50:33,747Z    tap -     line = self._fp.fp.readline()
2023-03-20 03:50:33,747Z    tap -   File "/root/.pyenv/versions/3.9.6/lib/python3.9/socket.py", line 704, in readinto
2023-03-20 03:50:33,748Z    tap -     return self._sock.recv_into(b)
2023-03-20 03:50:33,748Z    tap -   File "/root/.pyenv/versions/3.9.6/lib/python3.9/ssl.py", line 1241, in recv_into
2023-03-20 03:50:33,748Z    tap -     return self.read(nbytes, buffer)
2023-03-20 03:50:33,748Z    tap -   File "/root/.pyenv/versions/3.9.6/lib/python3.9/ssl.py", line 1099, in read
2023-03-20 03:50:33,748Z    tap -     return self._sslobj.read(len, buffer)
2023-03-20 03:50:33,748Z    tap - ConnectionResetError: [Errno 104] Connection reset by peer
```
It's observed that when an API from Active-Campaign returns 
an empty byte b'' response for a 200 status code, then, ChunkedEncodingError/JSONDecodeError is thrown in tap's response.
1) Added logic to handle ChunkedEncodingError and JSONDecodeError. 
2) Added necessary unit test case.

# Manual QA steps
 - Referred to customer logs and wrote a test API to test the errors.
 
# Risks
 - Low Risk
 
# Rollback steps
 - revert this branch
