### PR TITLE
Fix the none type error exception when no records found

### DIFF
--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -389,8 +389,8 @@ class ActiveCampaign:
 
             # Parent record batch
             # Get pagination details
-            total_count = data.get('meta', {}).get('total', 0)
-            api_total = 0 if total_count is None else int(total_count)
+            total_count = data.get('meta', {}).get('total') or 0
+            api_total = int(total_count)
 
             if api_total == 0:
                 total_records = record_count

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -389,7 +389,9 @@ class ActiveCampaign:
 
             # Parent record batch
             # Get pagination details
-            api_total = int(data.get('meta', {}).get('total', 0))
+            total_count = data.get('meta', {}).get('total', 0)
+            api_total = 0 if total_count is None else int(total_count)
+
             if api_total == 0:
                 total_records = record_count
             else:


### PR DESCRIPTION
# Description of change
In a few cases, API sends the response - `{'contactData': [], 'meta': {'total': None}}` due to which the API total count gets assigned to None, and the following exception is raised - _TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'_
This PR fixes the above issue by assigning the value of the API total to 0 whenever the total is None.
Jira - [TDL-22422](https://jira.talendforge.org/browse/TDL-22422)

# Manual QA steps
 - Tested the sync locally.
 
# Risks
 - Low
 
# Rollback steps
 - revert this branch
