### PR TITLE
Removed integer type from style.border.padding for forms stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Remove integer type for forms style.button.padding [#39](https://github.com/singer-io/tap-activecampaign/pull/39)
+
 ## 1.0.0
   * Add phone to list of supported fields [#26](https://github.com/singer-io/tap-activecampaign/pull/26)
   * Add string type for forms style.button.padding [#28](https://github.com/singer-io/tap-activecampaign/pull/28)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-activecampaign',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_activecampaign/schemas/forms.json
+++ b/tap_activecampaign/schemas/forms.json
@@ -114,7 +114,7 @@
           "additionalProperties": false,
           "properties": {
             "padding": {
-              "type": ["null", "integer", "string"]
+              "type": ["null", "string"]
             },
             "background": {
               "type": ["null", "string"]


### PR DESCRIPTION
# Description of change
Removed integer type from style.border.padding for forms stream.
This is done to avoid column splits due to 2 different datatypes "string" & "integer" for the field _style.border.padding_

# Manual QA steps
 - Ran sync locally.
 
# Risks
 - low risk
 
# Rollback steps
 - revert this branch
