### PR TITLE
Tdl 26421 fix contacts replication key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+  * Update replication key for `contacts` stream [#41](https://github.com/singer-io/tap-activecampaign/pull/41)
+
 ## 1.0.1
   * Remove integer type for forms style.button.padding [#39](https://github.com/singer-io/tap-activecampaign/pull/39)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Remove integer type for forms style.button.padding [#39](https://github.com/singer-io/tap-activecampaign/pull/39)
+
 ## 1.0.0
   * Add phone to list of supported fields [#26](https://github.com/singer-io/tap-activecampaign/pull/26)
   * Add string type for forms style.button.padding [#28](https://github.com/singer-io/tap-activecampaign/pull/28)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-activecampaign',
-      version='1.0.1',
+      version='1.1.0',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-activecampaign',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the Google Search Console API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_activecampaign/schema.py
+++ b/tap_activecampaign/schema.py
@@ -37,8 +37,11 @@ def get_schemas():
         mdata = metadata.to_map(mdata)
         # Loop through all keys and make replication keys of automatic inclusion
         for field_name in schema['properties'].keys():
-            
+
             if stream_metadata.get('replication_keys') and field_name in stream_metadata.get('replication_keys'):
+                mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
+
+            if stream_metadata.get('additional_automatic_keys') and field_name in stream_metadata.get('additional_automatic_keys'):
                 mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
 
         mdata = metadata.to_list(mdata)

--- a/tap_activecampaign/schema.py
+++ b/tap_activecampaign/schema.py
@@ -37,12 +37,10 @@ def get_schemas():
         mdata = metadata.to_map(mdata)
         # Loop through all keys and make replication keys of automatic inclusion
         for field_name in schema['properties'].keys():
-
-            if stream_metadata.get('replication_keys') and field_name in stream_metadata.get('replication_keys'):
-                mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
-
-            if stream_metadata.get('additional_automatic_keys') and field_name in stream_metadata.get('additional_automatic_keys'):
-                mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
+            for key in ['replication_keys', 'additional_automatic_keys']:
+                field_list = stream_metadata.get(key) or []
+                if field_name in field_list:
+                    mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
 
         mdata = metadata.to_list(mdata)
         field_metadata[stream_name] = mdata

--- a/tap_activecampaign/schema.py
+++ b/tap_activecampaign/schema.py
@@ -37,10 +37,10 @@ def get_schemas():
         mdata = metadata.to_map(mdata)
         # Loop through all keys and make replication keys of automatic inclusion
         for field_name in schema['properties'].keys():
-            for key in ['replication_keys', 'additional_automatic_keys']:
-                field_list = stream_metadata.get(key) or []
-                if field_name in field_list:
-                    mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
+            automatic_keys = ((stream_metadata.get('replication_keys') or []) +
+                              (stream_metadata.get('additional_automatic_keys') or []))
+            if field_name in automatic_keys:
+                mdata = metadata.write(mdata, ('properties', field_name), 'inclusion', 'automatic')
 
         mdata = metadata.to_list(mdata)
         field_metadata[stream_name] = mdata

--- a/tap_activecampaign/schemas/forms.json
+++ b/tap_activecampaign/schemas/forms.json
@@ -114,7 +114,7 @@
           "additionalProperties": false,
           "properties": {
             "padding": {
-              "type": ["null", "integer", "string"]
+              "type": ["null", "string"]
             },
             "background": {
               "type": ["null", "string"]

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -528,16 +528,17 @@ class CampaignLinks(ActiveCampaign):
 
 class Contacts(ActiveCampaign):
     """
-    Get data for contacts. 
+    Get data for contacts.
     Reference : https://developers.activecampaign.com/reference#list-all-contacts
     """
     stream_name = 'contacts'
-    replication_keys = ['updated_timestamp']
+    replication_keys = ['udate']
     path = 'contacts'
     data_key = 'contacts'
     created_timestamp = 'created_timestamp'
     bookmark_query_field = 'filters[updated_after]'
     links = ['contactGoals', 'contactLogs', 'geoIps', 'trackingLogs']
+
 
 class ContactAutomations(ActiveCampaign):
     """

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -30,7 +30,7 @@ class ActiveCampaign:
     replication_method = 'INCREMENTAL'
     replication_keys = None
     key_properties = ['id']
-    additional_automatic_keys = None
+    additional_automatic_keys = []
     path = None
     params = {}
     parent = None

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -287,6 +287,8 @@ class ActiveCampaign:
                 # For each parent record
                 for record in transformed_data:
                     i = 0
+                    parent_id_field = None
+
                     # Set parent_id
                     for id_field in id_fields:
                         if i == 0:

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -25,11 +25,12 @@ class ActiveCampaign:
     A base class representing singer streams.
     :param client: The API client used to extract records from external source
     """
-    
+
     stream_name = None
     replication_method = 'INCREMENTAL'
     replication_keys = None
     key_properties = ['id']
+    additional_automatic_keys = None
     path = None
     params = {}
     parent = None
@@ -38,7 +39,7 @@ class ActiveCampaign:
     bookmark_query_field = None
     links = []
     children = []
-    
+
     def __init__(self, client: ActiveCampaignClient = None):
         self.client = client
 
@@ -533,6 +534,7 @@ class Contacts(ActiveCampaign):
     """
     stream_name = 'contacts'
     replication_keys = ['udate']
+    additional_automatic_keys = ['updated_timestamp']
     path = 'contacts'
     data_key = 'contacts'
     created_timestamp = 'created_timestamp'
@@ -1111,7 +1113,8 @@ def flatten_streams():
       flat_streams[stream.stream_name] = {
             'key_properties': stream.key_properties,
             'replication_method': stream.replication_method,
-            'replication_keys': stream.replication_keys
+            'replication_keys': stream.replication_keys,
+            'additional_automatic_keys': stream.additional_automatic_keys
         }
 
     return flat_streams

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,6 +15,7 @@ class ActiveCampaignTest(unittest.TestCase):
     PRIMARY_KEYS = "table-key-properties"
     REPLICATION_METHOD = "forced-replication-method"
     REPLICATION_KEYS = "valid-replication-keys"
+    ADDITIONAL_AUTOMATIC_KEYS = 'additional_automatic_keys'
     FULL_TABLE = "FULL_TABLE"
     INCREMENTAL = "INCREMENTAL"
     OBEYS_START_DATE = "obey-start-date"
@@ -119,7 +120,8 @@ class ActiveCampaignTest(unittest.TestCase):
             'contacts': {
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {'updated_timestamp'},
+                self.REPLICATION_KEYS: {'udate'},
+                self.ADDITIONAL_AUTOMATIC_KEYS: {'updated_timestamp'},
                 self.OBEYS_START_DATE: True
             },
             'contact_automations': {
@@ -418,12 +420,12 @@ class ActiveCampaignTest(unittest.TestCase):
         """return a dictionary with key of table name nd value of replication method"""
         return {table: properties.get(self.REPLICATION_METHOD, set()) for table, properties
                 in self.expected_metadata().items()}
-        
+
     def expected_automatic_fields(self):
         """return a dictionary with key of table name and set of value of automatic(primary key and bookmark field) fields"""
         auto_fields = {}
         for k, v in self.expected_metadata().items():
-            auto_fields[k] = v.get(self.PRIMARY_KEYS, set()) |  v.get(self.REPLICATION_KEYS, set())
+            auto_fields[k] = v.get(self.PRIMARY_KEYS, set()) |  v.get(self.REPLICATION_KEYS, set()) | v.get(self.ADDITIONAL_AUTOMATIC_KEYS, set())
         return auto_fields
 
     def run_and_verify_check_mode(self, conn_id):

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -28,8 +28,9 @@ class ActiveCampaignAllFields(ActiveCampaignTest):
 
         # We are not able to generate data for `contact_conversions` stream. 
         # For `sms` stream it requires Professional plan of account. So, removing it from streams_to_test set.
-        expected_streams = expected_streams - {'contact_conversions', 'sms'}
-        
+        # BUG TDL-26417: Skip 'bounce_logs'
+        expected_streams = expected_streams - {'bounce_logs', 'contact_conversions', 'sms'}
+
         expected_automatic_fields = self.expected_automatic_fields()
         conn_id = connections.ensure_connection(self)
 

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -29,7 +29,8 @@ class ActiveCampaignBookMark(ActiveCampaignTest):
         expected_streams = self.expected_check_streams()
         # We are not able to generate data for `contact_conversions` stream.
         # For `sms` stream it requires Enterprise plan of account. So, removing it from expected_streams set.
-        expected_streams = expected_streams - {'contact_conversions', 'sms'}
+        # BUG TDL-26417: Skip 'bounce_logs'
+        expected_streams = expected_streams - {'bounce_logs', 'contact_conversions', 'sms'}
 
         expected_replication_keys = self.expected_replication_keys()
         expected_replication_methods = self.expected_replication_method()

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -48,7 +48,8 @@ class InterruptedSyncTest(ActiveCampaignTest):
         conn_id = connections.ensure_connection(self)
 
         # Note: test data not available for following streams: contact_conversions, sms
-        streams_to_test = self.expected_check_streams() - {'contact_conversions', 'sms'}
+        # BUG TDL-26417: Skip 'bounce_logs'
+        streams_to_test = self.expected_check_streams() - {'bounce_logs', 'contact_conversions', 'sms'}
 
         # Run check mode
         found_catalogs = self.run_and_verify_check_mode(conn_id)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -26,7 +26,8 @@ class ActiveCampaignPagination(ActiveCampaignTest):
         # `brandings`, `configs`, `conversions`, `conversion_triggers`, `goals`, `contact_conversions`, `sms`, `user`.
         # The current plan allows only 25 users. So, skipped `user` stream. sms feature is not supported for the current plan.
         # So, removing it all from expected_streams set.
-        expected_streams = expected_streams - {'contact_conversions', 'sms', 'users', 'brandings', 'configs', 'conversions', 'conversion_triggers', 'goals'}
+        # BUG TDL-26417: Skip 'bounce_logs'
+        expected_streams = expected_streams - {'bounce_logs', 'contact_conversions', 'sms', 'users', 'brandings', 'configs', 'conversions', 'conversion_triggers', 'goals'}
 
         conn_id = connections.ensure_connection(self)
 

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -29,7 +29,8 @@ class ActiveCampaignStartDate(ActiveCampaignTest):
 
         # We are not able to generate data for `contact_conversions`stream. 
         # For `sms` stream it requires Enterprise plan of account. So, removing it from streams_to_test set.
-        expected_streams = expected_streams - {'contact_conversions', 'sms'}
+        # BUG TDL-26417: Skip 'bounce_logs'
+        expected_streams = expected_streams - {'bounce_logs', 'contact_conversions', 'sms'}
 
         stream_to_test_1 = {'scores', 'contact_data', 'forms', 'templates'}
         self.run_test(days=4, expected_streams= stream_to_test_1)


### PR DESCRIPTION
# Description of change
Ticket [TDL-26421 ](https://jira.talendforge.org/browse/TDL-26421)

Pipedrive [contacts endpoint](https://developers.activecampaign.com/reference/list-all-contacts) filter `filters[updated_after]` in compared with `udate`. But currently tap is using `updated_timestamp` as replication key to bookmark and filter the latest records.

This PR fixes this behaviour by replacing replication key `updated_timestamp` by `udate` and set `updated_timestamp` as automatic key to ensure existing connections don't deselect the field.


# Manual QA steps

## Existing connection with custom field selections:
- [x] Verify tap runs as expected
- [x] Verify `udate` and `updated_timestamp` fields are selected
- [x] Verify other field selections still persist


## Existing connection tracking all the fields:

- [x] Verify tap runs as expected
- [x] Verify `udate` and `updated_timestamp` fields are selected
- [x] Verify other field selections still persist

<img width="218" alt="image" src="https://github.com/user-attachments/assets/bc26d6cb-7937-4b6f-8988-016b38bf662d">



 
# Risks
 - 
 
# Rollback steps
 - revert this branch
