### PR TITLE
SAC-28675: Python Upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,9 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            uv venv --python 3.9 /usr/local/share/virtualenvs/tap-activecampaign
+            uv venv --python 3.12 /usr/local/share/virtualenvs/tap-activecampaign
             source /usr/local/share/virtualenvs/tap-activecampaign/bin/activate
-            uv pip install 'pip==21.1.3'
-            uv pip install 'setuptools==56.0.0'
+            uv pip install setuptools
             uv pip install .[test]
       - run:
           name: 'JSON Validator'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(name='tap-activecampaign',
       install_requires=[
           'backoff==1.10.0',
           'requests==2.32.4',
-          'pyhumps==1.3.1',
           'singer-python==5.13.2'
       ],
       entry_points='''

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name='tap-activecampaign',
       py_modules=['tap_activecampaign'],
       install_requires=[
           'backoff==1.10.0',
+          'camel-converter==4.0.1',
           'requests==2.32.4',
           'singer-python==5.13.2'
       ],

--- a/tap_activecampaign/transform.py
+++ b/tap_activecampaign/transform.py
@@ -1,6 +1,5 @@
 import re
 import singer
-import humps
 
 LOGGER = singer.get_logger()
 
@@ -19,12 +18,16 @@ def fix_records(this_json):
         new_json.append(rec)
 
 
+SPLIT_RE = re.compile(r"([\-_]*(?<=[^0-9])(?=[A-Z])[^A-Z]*[\-_]*)")
+def to_snake_case(input):
+    return "_".join(s for s in SPLIT_RE.split(input) if s)
+
 def transform_json(this_json, stream_name, data_key):
     if data_key in this_json:
-        converted_json = humps.decamelize(this_json[data_key])
+        converted_json = to_snake_case(this_json[data_key])
     else:
-        converted_json = humps.decamelize(this_json)
-    
+        converted_json = to_snake_case(this_json)
+
     fix_records(converted_json)
 
     return converted_json

--- a/tap_activecampaign/transform.py
+++ b/tap_activecampaign/transform.py
@@ -24,10 +24,11 @@ def to_snake_case(input):
 
 def transform_json(this_json, stream_name, data_key):
     if data_key in this_json:
-        converted_json = to_snake_case(this_json[data_key])
+        json_list = this_json[data_key]
     else:
-        converted_json = to_snake_case(this_json)
+        json_list = this_json
 
+    converted_json = [to_snake_case(val) for val in json_list]
     fix_records(converted_json)
 
     return converted_json

--- a/tap_activecampaign/transform.py
+++ b/tap_activecampaign/transform.py
@@ -1,4 +1,5 @@
 import re
+from camel_converter import dict_to_snake
 import singer
 
 LOGGER = singer.get_logger()
@@ -18,17 +19,12 @@ def fix_records(this_json):
         new_json.append(rec)
 
 
-SPLIT_RE = re.compile(r"([\-_]*(?<=[^0-9])(?=[A-Z])[^A-Z]*[\-_]*)")
-def to_snake_case(input):
-    return "_".join(s for s in SPLIT_RE.split(input) if s)
-
 def transform_json(this_json, stream_name, data_key):
     if data_key in this_json:
-        json_list = this_json[data_key]
+        converted_json = dict_to_snake(this_json[data_key])
     else:
-        json_list = this_json
+        converted_json = dict_to_snake(this_json)
 
-    converted_json = [to_snake_case(val) for val in json_list]
     fix_records(converted_json)
 
     return converted_json

--- a/tap_activecampaign/transform.py
+++ b/tap_activecampaign/transform.py
@@ -21,9 +21,11 @@ def fix_records(this_json):
 
 def transform_json(this_json, stream_name, data_key):
     if data_key in this_json:
-        converted_json = dict_to_snake(this_json[data_key])
+        json_list = this_json[data_key]
     else:
-        converted_json = dict_to_snake(this_json)
+        json_list = this_json
+
+    converted_json = [dict_to_snake(list_item) for list_item in json_list]
 
     fix_records(converted_json)
 

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -12,22 +12,22 @@ class ActiveCampaignAllFields(ActiveCampaignTest):
         "contact_lists": {'ip_4unsub', 'ip_4sub'},
         "users": {'password_updated_utc_timestamp', 'cdate', 'udate'}
         }
-     
+
     def name(self):
         return "activecampaign_all_fields"
 
     def test_run(self):
         """
         • Verify no unexpected streams were replicated
-        • Verify that more than just the automatic fields are replicated for each stream. 
+        • Verify that more than just the automatic fields are replicated for each stream.
         • verify all fields for each stream are replicated
         """
-        
-        
+
+
         # Streams to verify all fields tests
         expected_streams = self.expected_check_streams()
 
-        # We are not able to generate data for `contact_conversions` stream. 
+        # We are not able to generate data for `contact_conversions` stream.
         # For `sms` stream it requires Professional plan of account. So, removing it from streams_to_test set.
         # BUG TDL-26417: Skip 'bounce_logs'
         expected_streams = expected_streams - {'bounce_logs', 'contact_conversions', 'sms'}
@@ -63,8 +63,8 @@ class ActiveCampaignAllFields(ActiveCampaignTest):
         # Verify no unexpected streams were replicated
         synced_stream_names = set(synced_records.keys())
         self.assertSetEqual(expected_streams, synced_stream_names)
-        
-        
+
+
         for stream in expected_streams:
             with self.subTest(stream=stream):
 
@@ -86,6 +86,6 @@ class ActiveCampaignAllFields(ActiveCampaignTest):
 
                 # As we can't generate following field by activecampaign APIs and UI, so removed it form expectation list.
                 expected_all_keys = expected_all_keys - self.MISSING_FIELDS.get(stream, set())
-                    
+
                 # verify all fields for each stream are replicated
                 self.assertSetEqual(expected_all_keys, actual_all_keys)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -9,6 +9,7 @@ class ActiveCampaignAllFields(ActiveCampaignTest):
     MISSING_FIELDS = {
         "ecommerce_orders": {'order_products'},
         "contacts": {'email_empty'},
+        "contact_lists": {'ip_4unsub', 'ip_4sub'},
         "users": {'password_updated_utc_timestamp', 'cdate', 'udate'}
         }
      

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -17,7 +17,7 @@ class TestBackoffError(unittest.TestCase):
         client = ActiveCampaignClient("https://www.activecampaign.com", "dummy_api_token")
         with self.assertRaises(Timeout):
             client.request("GET")
-        self.assertEquals(mock_request.call_count, 5)
+        self.assertEqual(mock_request.call_count, 5)
 
     @mock.patch('tap_activecampaign.client.requests.Session.request')
     def test_check_api_token_timeout_and_backoff(self, mocked_request):
@@ -40,8 +40,8 @@ class TestBackoffError(unittest.TestCase):
                 pass
         except Timeout:
             # verify that we backoff for 5 times
-            self.assertEquals(mocked_request.call_count, 5)
-        
+            self.assertEqual(mocked_request.call_count, 5)
+
     @mock.patch('tap_activecampaign.client.requests.Session.request')
     def test_check_api_token_connection_error_and_backoff(self, mocked_request):
         """
@@ -63,11 +63,11 @@ class TestBackoffError(unittest.TestCase):
                 pass
         except ConnectionError:
             # verify that we backoff for 5 times
-            self.assertEquals(mocked_request.call_count, 5)
+            self.assertEqual(mocked_request.call_count, 5)
 
 class MockResponse():
     '''
-    Mock response  object for the requests call 
+    Mock response  object for the requests call
     '''
     def __init__(self, resp, status_code, content=[""], headers=None, raise_error=False, text={}):
         self.json_data = resp


### PR DESCRIPTION
# Description of change
This PR includes all of the changes needed to get this tap to run on python 3.12.X.

# Manual QA steps
 - None, I'm letting integration tests catch issues
 
# Risks
 - Low. The biggest risk here is that `pyhumps` and `camel-converter` split camel-cased words differently.
   - `camel-converter` also doesn't convert string values, but `pyhumps` did. Whether this is important or not depends on whether the API returned data values as camelcased strings.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
