### PR TITLE
SAC-28675: `pyhumps` is back

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='tap-activecampaign',
       py_modules=['tap_activecampaign'],
       install_requires=[
           'backoff==1.10.0',
-          'camel-converter==4.0.1',
+          'pyhumps==3.8.0',
           'requests==2.32.4',
           'singer-python==5.13.2'
       ],

--- a/tap_activecampaign/transform.py
+++ b/tap_activecampaign/transform.py
@@ -1,5 +1,5 @@
 import re
-from camel_converter import dict_to_snake
+import humps
 import singer
 
 LOGGER = singer.get_logger()
@@ -21,11 +21,9 @@ def fix_records(this_json):
 
 def transform_json(this_json, stream_name, data_key):
     if data_key in this_json:
-        json_list = this_json[data_key]
+        converted_json = humps.decamelize(this_json[data_key])
     else:
-        json_list = this_json
-
-    converted_json = [dict_to_snake(list_item) for list_item in json_list]
+        converted_json = humps.decamelize(this_json)
 
     fix_records(converted_json)
 


### PR DESCRIPTION
# Description of change
Not sure how I missed this version of `pyhumps` in my testing, but based off of https://github.com/singer-io/tap-pendo/pull/136 I wanted to put this dependency back in

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
