### PR TITLE
Exclude unauthorized streams in catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,9 @@ venv/
 build/
 tap_target_commands.sh
 .vscode
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.0
+  * Exclude streams with unauthorized access from catalog during discovery [#55](https://github.com/singer-io/tap-activecampaign/pull/55)
+  * Upgrade backoff lib version to 2.2.1, requests to 2.34.2, singer-python to 6.8.0
+
 ## 1.4.0
   * Replace base url with /users/me for token validation [#53](https://github.com/singer-io/tap-activecampaign/pull/53)
   * Bump requests from 2.32.4 to 2.33.0 [#54](https://github.com/singer-io/tap-activecampaign/pull/54)

--- a/setup.py
+++ b/setup.py
@@ -3,16 +3,16 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-activecampaign',
-      version='1.4.0',
-      description='Singer.io tap for extracting data from the Google Search Console API',
+      version='1.5.0',
+      description='Singer.io tap for extracting data from the ActiveCampaign API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_activecampaign'],
       install_requires=[
-          'backoff==1.10.0',
+          'backoff==2.2.1',
           'pyhumps==3.8.0',
-          'requests==2.33.0',
-          'singer-python==5.13.2'
+          'requests==2.34.2',
+          'singer-python==6.8.0'
       ],
       entry_points='''
           [console_scripts]
@@ -30,7 +30,8 @@ setup(name='tap-activecampaign',
               'ipdb',
           ],
           'test': [
+              'coverage',
               'pylint',
-              'nose',
+              'pytest',
           ]
       })

--- a/tap_activecampaign/__init__.py
+++ b/tap_activecampaign/__init__.py
@@ -1,8 +1,6 @@
 import sys
 import json
-import argparse
 import singer
-from singer import metadata, utils
 from tap_activecampaign.client import ActiveCampaignClient
 from tap_activecampaign.discover import discover
 from tap_activecampaign.sync import sync

--- a/tap_activecampaign/__init__.py
+++ b/tap_activecampaign/__init__.py
@@ -16,10 +16,10 @@ REQUIRED_CONFIG_KEYS = [
     'user_agent'
 ]
 
-def do_discover():
+def do_discover(client):
 
     LOGGER.info('Starting discover')
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info('Finished discover')
 
@@ -39,7 +39,7 @@ def main():
             state = parsed_args.state
 
         if parsed_args.discover:
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(client=client,
                  config=parsed_args.config,

--- a/tap_activecampaign/client.py
+++ b/tap_activecampaign/client.py
@@ -6,79 +6,28 @@ import requests
 from singer import metrics, utils
 import singer
 
+from tap_activecampaign.exceptions import (
+    Server5xxError,
+    Server429Error,
+    ActiveCampaignError,
+    ActiveCampaignBadRequestError,
+    ActiveCampaignUnauthorizedError,
+    ActiveCampaignForbiddenError,
+    ActiveCampaignNotFoundError,
+    ActiveCampaignUnprocessableEntityError,
+    ActiveCampaignRateLimitError,
+    ActiveCampaignInternalServerError,
+    STATUS_CODE_EXCEPTION_MAPPING,
+)
+
+
 LOGGER = singer.get_logger()
 REQUEST_TIMEOUT = 300
 
 DEFAULT_API_VERSION = '3'
 
-
-class Server5xxError(Exception):
-    pass
-
-
-class Server429Error(Exception):
-    pass
-
-
-class ActiveCampaignError(Exception):
-    pass
-class ActiveCampaignBadRequestError(ActiveCampaignError):
-    pass
-
-class ActiveCampaignUnauthorizedError(ActiveCampaignError):
-    pass
-
-class ActiveCampaignForbiddenError(ActiveCampaignError):
-    pass
-
-class ActiveCampaignNotFoundError(ActiveCampaignError):
-    pass
-
-class ActiveCampaignUnprocessableEntityError(ActiveCampaignError):
-    pass
-
-class ActiveCampaignRateLimitError(Server429Error):
-    pass
-
-class ActiveCampaignInternalServerError(Server5xxError):
-    pass
-
-
-# Errors Reference: https://developers.activecampaign.com/reference#errors
-STATUS_CODE_EXCEPTION_MAPPING = {
-    400: {
-        "raise_exception": ActiveCampaignBadRequestError,
-        "message": "A validation exception has occurred."
-    },
-    401: {
-        "raise_exception": ActiveCampaignUnauthorizedError,
-        "message": "Invalid authorization credentials."
-    },
-    403: {
-        "raise_exception": ActiveCampaignForbiddenError,
-        "message": "The request could not be authenticated or the authenticated user is not authorized to access the requested resource."
-    },
-    404: {
-        "raise_exception": ActiveCampaignNotFoundError,
-        "message": "The requested resource does not exist."
-    },
-    422: {
-        "raise_exception": ActiveCampaignUnprocessableEntityError,
-        "message": "The request could not be processed, usually due to a missing or invalid parameter."
-    },
-    429: {
-        "raise_exception": ActiveCampaignRateLimitError,
-        "message": "The user has sent too many requests in a given amount of time ('rate limiting') - contact support or account manager for more details."
-    },
-    500: {
-        "raise_exception": ActiveCampaignInternalServerError,
-        "message": "The server encountered an unexpected condition which prevented" \
-            " it from fulfilling the request."
-    }
-}
-
 def should_retry_error(exception):
-    """ 
+    """
         Return true if exception is required to retry otherwise return false
     """
 
@@ -137,7 +86,7 @@ def raise_for_error(response):
         message = "HTTP-error-code: {}, Error: {}".format(status_code,
                 response_json.get("message", STATUS_CODE_EXCEPTION_MAPPING.get(
                 status_code, {}).get("message", "Unknown Error")))
-    
+
     exc = get_exception_for_status_code(status_code)
 
     raise exc(message) from None
@@ -164,7 +113,6 @@ def is_api_url_valid(api_url):
             return False
 
     return True
-
 
 
 class ActiveCampaignClient(object):

--- a/tap_activecampaign/discover.py
+++ b/tap_activecampaign/discover.py
@@ -7,11 +7,13 @@ from tap_activecampaign.exceptions import ActiveCampaignDiscoveryForbiddenError
 LOGGER = singer.get_logger()
 
 
-def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> list:
     """
     Remove child streams from the catalog whose parent stream was excluded.
     Mutates schemas and field_metadata in place.
+    Returns the list of pruned child stream names.
     """
+    pruned = []
     for name, stream_cls in list(STREAMS.items()):
         if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
             LOGGER.warning(
@@ -20,6 +22,8 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
             )
             schemas.pop(name)
             field_metadata.pop(name)
+            pruned.append(name)
+    return pruned
 
 
 def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
@@ -39,7 +43,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
         schemas.pop(stream_name, None)
         field_metadata.pop(stream_name, None)
 
-    _prune_inaccessible_children(schemas, field_metadata)
+    pruned_children = _prune_inaccessible_children(schemas, field_metadata)
 
     if inaccessible_streams:
         total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
@@ -47,9 +51,10 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
             raise ActiveCampaignDiscoveryForbiddenError(
                 "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
             )
+        all_excluded = inaccessible_streams + pruned_children
         LOGGER.warning(
             "Unauthorized streams have been excluded: %s",
-            ", ".join(inaccessible_streams),
+            ", ".join(all_excluded),
         )
 
 

--- a/tap_activecampaign/discover.py
+++ b/tap_activecampaign/discover.py
@@ -1,76 +1,64 @@
-import singer
+﻿import singer
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_activecampaign.schema import get_schemas
 from tap_activecampaign.streams import STREAMS, flatten_streams
-from tap_activecampaign.exceptions import ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError
+from tap_activecampaign.exceptions import ActiveCampaignDiscoveryForbiddenError
 
 LOGGER = singer.get_logger()
 
 
-class ActiveCampaignDiscoveryForbiddenError(Exception):
-    pass
-
-
-def check_stream_access(client, stream_name, path):
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
     """
-    Return True if the stream endpoint is accessible with the current credentials,
-    False if a 403 or 401 response is received.
-    Re-raises any other exception.
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas and field_metadata in place.
     """
-    try:
-        client.get(path=path, params={'limit': 1}, endpoint=stream_name)
-        return True
-    except (ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError):
-        return False
+    for name, stream_cls in list(STREAMS.items()):
+        if name in schemas and stream_cls.parent and stream_cls.parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name, stream_cls.parent,
+            )
+            schemas.pop(name)
+            field_metadata.pop(name)
 
 
-def _get_accessible_streams(client, schemas, flat_streams):
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
     """
-    Probe each parent stream endpoint to determine which streams the API token
-    can access. Returns a filtered copy of `schemas` that excludes inaccessible
-    parent streams and any child streams whose parent is inaccessible.
-
-    Raises ActiveCampaignDiscoveryForbiddenError if no streams are accessible.
+    Probe each parent stream for read access and remove inaccessible streams
+    (and their children) from schemas and field_metadata in place.
+    Raises ActiveCampaignDiscoveryForbiddenError if no parent streams are accessible.
     """
-    inaccessible_streams = []
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_obj in STREAMS.items()
+        if stream_name in schemas
+        and not stream_obj(client=client).check_access()
+    ]
 
-    for stream_name in list(schemas.keys()):
-        # Skip child streams — their paths require a parent record id
-        if flat_streams.get(stream_name, {}).get('parent_tap_stream_id'):
-            continue
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
 
-        stream_cls = STREAMS[stream_name]
-        if not check_stream_access(client, stream_name, stream_cls.path):
-            inaccessible_streams.append(stream_name)
+    _prune_inaccessible_children(schemas, field_metadata)
 
     if inaccessible_streams:
+        total_parent_streams = len([s for s in STREAMS.values() if not s.parent])
+        if len(inaccessible_streams) == total_parent_streams:
+            raise ActiveCampaignDiscoveryForbiddenError(
+                "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
+            )
         LOGGER.warning(
-            'The following streams are not accessible and will be excluded '
-            'from the catalog: %s', ', '.join(inaccessible_streams)
+            "No 'read' access to stream(s): '%s'. Excluded from catalog.",
+            ", ".join(inaccessible_streams),
         )
-
-    # Exclude inaccessible parent streams and their child streams
-    filtered_schemas = {
-        name: schema
-        for name, schema in schemas.items()
-        if name not in inaccessible_streams
-        and flat_streams.get(name, {}).get('parent_tap_stream_id') not in inaccessible_streams
-    }
-
-    if not filtered_schemas:
-        raise ActiveCampaignDiscoveryForbiddenError(
-            'Access denied: no streams are accessible with the provided credentials.'
-        )
-
-    return filtered_schemas
 
 
 def discover(client):
     schemas, field_metadata = get_schemas()
-    catalog = Catalog([])
+    _apply_access_checks(client, schemas, field_metadata)
 
+    catalog = Catalog([])
     flat_streams = flatten_streams()
-    schemas = _get_accessible_streams(client, schemas, flat_streams)
 
     for stream_name, schema_dict in schemas.items():
         try:

--- a/tap_activecampaign/discover.py
+++ b/tap_activecampaign/discover.py
@@ -1,15 +1,77 @@
 import singer
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_activecampaign.schema import get_schemas
-from tap_activecampaign.streams import flatten_streams
+from tap_activecampaign.streams import STREAMS, flatten_streams
+from tap_activecampaign.client import ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError
 
 LOGGER = singer.get_logger()
 
-def discover():
+
+class ActiveCampaignDiscoveryForbiddenError(Exception):
+    pass
+
+
+def check_stream_access(client, stream_name, path):
+    """
+    Return True if the stream endpoint is accessible with the current credentials,
+    False if a 403 or 401 response is received.
+    Re-raises any other exception.
+    """
+    try:
+        client.get(path=path, params='limit=1', endpoint=stream_name)
+        return True
+    except (ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError):
+        return False
+
+
+def _get_accessible_streams(client, schemas, flat_streams):
+    """
+    Probe each parent stream endpoint to determine which streams the API token
+    can access. Returns a filtered copy of `schemas` that excludes inaccessible
+    parent streams and any child streams whose parent is inaccessible.
+
+    Raises ActiveCampaignDiscoveryForbiddenError if no streams are accessible.
+    """
+    inaccessible_streams = []
+
+    for stream_name in list(schemas.keys()):
+        # Skip child streams — their paths require a parent record id
+        if flat_streams.get(stream_name, {}).get('parent_tap_stream_id'):
+            continue
+
+        stream_cls = STREAMS[stream_name]
+        if not check_stream_access(client, stream_name, stream_cls.path):
+            inaccessible_streams.append(stream_name)
+
+    if inaccessible_streams:
+        LOGGER.warning(
+            'The following streams are not accessible and will be excluded '
+            'from the catalog: %s', ', '.join(inaccessible_streams)
+        )
+
+    # Exclude inaccessible parent streams and their child streams
+    filtered_schemas = {
+        name: schema
+        for name, schema in schemas.items()
+        if name not in inaccessible_streams
+        and flat_streams.get(name, {}).get('parent_tap_stream_id') not in inaccessible_streams
+    }
+
+    if not filtered_schemas:
+        raise ActiveCampaignDiscoveryForbiddenError(
+            'Access denied: no streams are accessible with the provided credentials.'
+        )
+
+    return filtered_schemas
+
+
+def discover(client):
     schemas, field_metadata = get_schemas()
     catalog = Catalog([])
 
     flat_streams = flatten_streams()
+    schemas = _get_accessible_streams(client, schemas, flat_streams)
+
     for stream_name, schema_dict in schemas.items():
         try:
             schema = Schema.from_dict(schema_dict)

--- a/tap_activecampaign/discover.py
+++ b/tap_activecampaign/discover.py
@@ -48,7 +48,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
                 "HTTP-error-code: 403, Error: The credentials do not have 'read' access to any supported streams."
             )
         LOGGER.warning(
-            "No 'read' access to stream(s): '%s'. Excluded from catalog.",
+            "Unauthorized streams have been excluded: %s",
             ", ".join(inaccessible_streams),
         )
 

--- a/tap_activecampaign/discover.py
+++ b/tap_activecampaign/discover.py
@@ -2,7 +2,7 @@ import singer
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_activecampaign.schema import get_schemas
 from tap_activecampaign.streams import STREAMS, flatten_streams
-from tap_activecampaign.client import ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError
+from tap_activecampaign.exceptions import ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError
 
 LOGGER = singer.get_logger()
 
@@ -18,7 +18,7 @@ def check_stream_access(client, stream_name, path):
     Re-raises any other exception.
     """
     try:
-        client.get(path=path, params='limit=1', endpoint=stream_name)
+        client.get(path=path, params={'limit': 1}, endpoint=stream_name)
         return True
     except (ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError):
         return False

--- a/tap_activecampaign/exceptions.py
+++ b/tap_activecampaign/exceptions.py
@@ -1,0 +1,75 @@
+class Server5xxError(Exception):
+    pass
+
+class Server429Error(Exception):
+    pass
+
+class ActiveCampaignError(Exception):
+    """Generic ActiveCampaign API error."""
+
+    def __init__(self, message=None, response=None):
+        super().__init__(message)
+        self.message = message
+        self.response = response
+
+class ActiveCampaignBadRequestError(ActiveCampaignError):
+    """HTTP 400 - Bad Request."""
+    pass
+
+class ActiveCampaignUnauthorizedError(ActiveCampaignError):
+    """HTTP 401 - Unauthorized."""
+    pass
+
+class ActiveCampaignForbiddenError(ActiveCampaignError):
+    """HTTP 403 - Forbidden."""
+    pass
+
+class ActiveCampaignNotFoundError(ActiveCampaignError):
+    """HTTP 404 - Not Found."""
+    pass
+
+class ActiveCampaignUnprocessableEntityError(ActiveCampaignError):
+    """HTTP 422 - Unprocessable Entity."""
+    pass
+
+class ActiveCampaignRateLimitError(Server429Error):
+    """HTTP 429 - Rate Limit Exceeded."""
+    pass
+
+class ActiveCampaignInternalServerError(Server5xxError):
+    """HTTP 500+ - Server Error."""
+    pass
+
+
+# Errors Reference: https://developers.activecampaign.com/reference#errors
+STATUS_CODE_EXCEPTION_MAPPING = {
+    400: {
+        "raise_exception": ActiveCampaignBadRequestError,
+        "message": "A validation exception has occurred."
+    },
+    401: {
+        "raise_exception": ActiveCampaignUnauthorizedError,
+        "message": "Invalid authorization credentials."
+    },
+    403: {
+        "raise_exception": ActiveCampaignForbiddenError,
+        "message": "The request could not be authenticated or the authenticated user is not authorized to access the requested resource."
+    },
+    404: {
+        "raise_exception": ActiveCampaignNotFoundError,
+        "message": "The requested resource does not exist."
+    },
+    422: {
+        "raise_exception": ActiveCampaignUnprocessableEntityError,
+        "message": "The request could not be processed, usually due to a missing or invalid parameter."
+    },
+    429: {
+        "raise_exception": ActiveCampaignRateLimitError,
+        "message": "The user has sent too many requests in a given amount of time ('rate limiting') - contact support or account manager for more details."
+    },
+    500: {
+        "raise_exception": ActiveCampaignInternalServerError,
+        "message": "The server encountered an unexpected condition which prevented"
+            " it from fulfilling the request."
+    }
+}

--- a/tap_activecampaign/exceptions.py
+++ b/tap_activecampaign/exceptions.py
@@ -40,6 +40,9 @@ class ActiveCampaignInternalServerError(Server5xxError):
     """HTTP 500+ - Server Error."""
     pass
 
+class ActiveCampaignDiscoveryForbiddenError(Exception):
+    pass
+
 
 # Errors Reference: https://developers.activecampaign.com/reference#errors
 STATUS_CODE_EXCEPTION_MAPPING = {

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -3,6 +3,7 @@ from singer import metrics, metadata, Transformer, utils
 from singer.utils import strptime_to_utc
 from tap_activecampaign.transform import transform_json
 from tap_activecampaign.client import ActiveCampaignClient
+from tap_activecampaign.exceptions import ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError
 
 LOGGER = singer.get_logger()
 # streams: API URL endpoints to be called
@@ -43,8 +44,28 @@ class ActiveCampaign:
     def __init__(self, client: ActiveCampaignClient = None):
         self.client = client
 
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 or 401 response is received.
+        Child streams always return True — access is governed by the parent stream check.
+        """
+        if self.parent:
+            return True
+
+        try:
+            self.client.get(path=self.path, params={'limit': 1}, endpoint=self.stream_name)
+            return True
+        except (ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError) as exc:
+            LOGGER.warning(
+                "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message:'%s'",
+                self.stream_name,
+                str(exc),
+            )
+            return False
+
     def write_schema(self, catalog, stream_name):
-        """ 
+        """
         Write a schema message.
         """
         stream = catalog.get_stream(stream_name)
@@ -59,7 +80,7 @@ class ActiveCampaign:
         except OSError as err:
             LOGGER.error('OS Error while writing schema for: {}'.format(stream_name))
             raise err
-        
+
     def write_record(self, stream_name, record, time_extracted):
         """
         Write a single record for the given stream.
@@ -77,7 +98,7 @@ class ActiveCampaign:
             raise err
 
     def get_bookmark(self, state, stream, default):
-        """ 
+        """
         Return bookmark value present in state or return a default value if no bookmark
         present in the state for provided stream
         """
@@ -249,7 +270,7 @@ class ActiveCampaign:
         Transform data with transform_json from transform.py
         """
         data_key = self.data_key
-        
+
         # The data_key identifies the array/list of records below the <root> element
         transformed_data = [] # initialize the record list
         data_list = []
@@ -270,7 +291,7 @@ class ActiveCampaign:
                 data_list.append(data)
                 data_dict[data_key] = data_list
                 transformed_data = transform_json(data_dict, self.stream_name, data_key)
-        
+
         return transformed_data
 
     def sync_child_stream(self, children, transformed_data, catalog, state, start_date, selected_streams):
@@ -278,7 +299,7 @@ class ActiveCampaign:
         sync the child stream. Loop through all children and if it is selected then collect data based on parent_id.
         """
         id_fields = self.key_properties
-        
+
         for child_stream_name in children:
             if child_stream_name in selected_streams:
                 LOGGER.info('START Syncing: {}'.format(child_stream_name))
@@ -324,11 +345,11 @@ class ActiveCampaign:
 
     def get_and_transform_records(self, querystring, path, max_bookmark_value, state, catalog, start_date, last_datetime, endpoint_total, 
                                   limit, total_records, record_count, page, offset, parent, parent_id, selected_streams):
-        
+
         """
         Get the records using the client get request and transform it using transform_records
         """
-        
+
         bookmark_field = next(iter(self.replication_keys or []), None)
         created_timestamp_field = self.created_timestamp
         id_fields = self.key_properties
@@ -339,15 +360,15 @@ class ActiveCampaign:
             path=path,
             params=querystring,
             endpoint=self.stream_name)
-        
+
         # time_extracted: datetime when the data was extracted from the API
         time_extracted = utils.now()
-        
+
         if not data or data is None or data == {}:
             LOGGER.info('No data for URL {}{}{}'.format(self.client.base_url, path, querystring)) # No data results
         else: # has data
             transformed_data = self.transform_data(data)
-            
+
             if not transformed_data or transformed_data is None:
                 LOGGER.info('No transformed data for data = {}'.format(data)) # No data results
 
@@ -368,7 +389,7 @@ class ActiveCampaign:
                             self.stream_name, key, record))
                         raise RuntimeError
                 i = i + 1
-        
+
             # Process records and get the max_bookmark_value and record_count for the set of records
             max_bookmark_value, record_count = self.process_records(
                 catalog=catalog,
@@ -421,7 +442,7 @@ class ActiveCampaign:
 
 class Accounts(ActiveCampaign):
     """
-    Get data for accounts. 
+    Get data for accounts.
     Reference : https://developers.activecampaign.com/reference#list-all-accounts
     """
     stream_name = 'accounts'
@@ -432,7 +453,7 @@ class Accounts(ActiveCampaign):
 
 class AccountContact(ActiveCampaign):
     """
-    Get data for account contact. 
+    Get data for account contact.
     Reference : https://developers.activecampaign.com/reference#list-all-associations-1
     """
     stream_name = 'account_contacts'
@@ -443,7 +464,7 @@ class AccountContact(ActiveCampaign):
 
 class AccountCustomFields(ActiveCampaign):
     """
-    Get data for account custom fields. 
+    Get data for account custom fields.
     Reference : https://developers.activecampaign.com/reference#list-all-custom-fields
     """
     stream_name = 'account_custom_fields'
@@ -454,7 +475,7 @@ class AccountCustomFields(ActiveCampaign):
 
 class AccountCustomFieldValues(ActiveCampaign):
     """
-    Get data for account custom field values. 
+    Get data for account custom field values.
     Reference : https://developers.activecampaign.com/reference#list-all-custom-field-values-2
     """
     stream_name = 'account_custom_field_values'
@@ -465,7 +486,7 @@ class AccountCustomFieldValues(ActiveCampaign):
 
 class Addresses(ActiveCampaign):
     """
-    Get data for addresses. 
+    Get data for addresses.
     Reference : https://developers.activecampaign.com/reference#list-all-addresses
     """
     stream_name = 'addresses'
@@ -476,7 +497,7 @@ class Addresses(ActiveCampaign):
 
 class Automations(ActiveCampaign):
     """
-    Get data for automations. 
+    Get data for automations.
     Reference : https://developers.activecampaign.com/reference#list-all-automations
     """
     stream_name = 'automations'
@@ -488,7 +509,7 @@ class Automations(ActiveCampaign):
 
 class Brandings(ActiveCampaign):
     """
-    Get data for brandings. 
+    Get data for brandings.
     Reference : https://developers.activecampaign.com/reference#brandings
     """
     stream_name = 'brandings'
@@ -498,7 +519,7 @@ class Brandings(ActiveCampaign):
 
 class Calendars(ActiveCampaign):
     """
-    Get data for calendars. 
+    Get data for calendars.
     Reference : https://developers.activecampaign.com/reference#list-all-calendar-feeds
     """
     stream_name = 'calendars'
@@ -510,7 +531,7 @@ class Calendars(ActiveCampaign):
 
 class Campaigns(ActiveCampaign):
     """
-    Get data for campaigns. 
+    Get data for campaigns.
     Reference : https://developers.activecampaign.com/reference#list-all-campaigns
     """
     stream_name = 'campaigns'
@@ -521,7 +542,7 @@ class Campaigns(ActiveCampaign):
 
 class CampaignLinks(ActiveCampaign):
     """
-    Get data for campaign_links. 
+    Get data for campaign_links.
     Reference : https://developers.activecampaign.com/reference#retrieve-links-associated-campaign
     """
     stream_name = 'campaign_links'
@@ -547,7 +568,7 @@ class Contacts(ActiveCampaign):
 
 class ContactAutomations(ActiveCampaign):
     """
-    Get data for contactAutomations. 
+    Get data for contactAutomations.
     Reference : https://developers.activecampaign.com/reference#list-all-contact-automations
     """
     stream_name = 'contact_automations'
@@ -558,7 +579,7 @@ class ContactAutomations(ActiveCampaign):
 
 class ContactCustomFields(ActiveCampaign):
     """
-    Get data for contact_custom_fields. 
+    Get data for contact_custom_fields.
     Reference : https://developers.activecampaign.com/reference#retrieve-fields-1
     """
     stream_name = 'contact_custom_fields'
@@ -568,7 +589,7 @@ class ContactCustomFields(ActiveCampaign):
 
 class ContactCustomFieldOptions(ActiveCampaign):
     """
-    Get data for contact_custom_field_options. 
+    Get data for contact_custom_field_options.
     Reference : https://developers.activecampaign.com/reference#retrieve-fields-1
     """
     stream_name = 'contact_custom_field_options'
@@ -578,7 +599,7 @@ class ContactCustomFieldOptions(ActiveCampaign):
 
 class ContactCustomFieldRels(ActiveCampaign):
     """
-    Get data for contact_custom_field_rels. 
+    Get data for contact_custom_field_rels.
     Reference : https://developers.activecampaign.com/reference#retrieve-fields-1
     """
     stream_name = 'contact_custom_field_rels'
@@ -588,7 +609,7 @@ class ContactCustomFieldRels(ActiveCampaign):
 
 class ContactCustomFieldValues(ActiveCampaign):
     """
-    Get data for contact_custom_field_values. 
+    Get data for contact_custom_field_values.
     Reference : https://developers.activecampaign.com/reference#list-all-custom-field-values-1
     """
     stream_name = 'contact_custom_field_values'
@@ -599,7 +620,7 @@ class ContactCustomFieldValues(ActiveCampaign):
 
 class ContactDeals(ActiveCampaign):
     """
-    Get data for contact_deals. 
+    Get data for contact_deals.
     Reference : https://developers.activecampaign.com/reference#list-all-secondary-contacts
     """
     stream_name = 'contact_deals'
@@ -610,7 +631,7 @@ class ContactDeals(ActiveCampaign):
 
 class DealStages(ActiveCampaign):
     """
-    Get data for deal_stages. 
+    Get data for deal_stages.
     Reference : https://developers.activecampaign.com/reference#list-all-deal-stages
     """
     stream_name = 'deal_stages'
@@ -618,10 +639,10 @@ class DealStages(ActiveCampaign):
     path = 'dealStages'
     data_key = 'dealStages'
     created_timestamp = 'cdate'
-    
+
 class DealGroups(ActiveCampaign):
     """
-    Get data for deal_groups. 
+    Get data for deal_groups.
     Reference : https://developers.activecampaign.com/reference#list-all-pipelines
     Also known as: pipelines
     """
@@ -634,7 +655,7 @@ class DealGroups(ActiveCampaign):
 
 class DealCustomFields(ActiveCampaign):
     """
-    Get data for deal_custom_fields. 
+    Get data for deal_custom_fields.
     Reference : https://developers.activecampaign.com/reference#retrieve-all-dealcustomfielddata-resources
     """
     stream_name = 'deal_custom_fields'
@@ -645,7 +666,7 @@ class DealCustomFields(ActiveCampaign):
 
 class DealCustomFieldValues(ActiveCampaign):
     """
-    Get data for deal_custom_field_values. 
+    Get data for deal_custom_field_values.
     Reference : https://developers.activecampaign.com/reference#list-all-custom-field-values
     """
     stream_name = 'deal_custom_field_values'
@@ -653,10 +674,10 @@ class DealCustomFieldValues(ActiveCampaign):
     path = 'dealCustomFieldData'
     data_key = 'dealCustomFieldData'
     created_timestamp = 'created_timestamp'
-    
+
 class Deals(ActiveCampaign):
     """
-    Get data for deals. 
+    Get data for deals.
     Reference : https://developers.activecampaign.com/reference#list-all-deals
     """
     stream_name = 'deals'
@@ -667,19 +688,19 @@ class Deals(ActiveCampaign):
 
 class EcommerceConnections(ActiveCampaign):
     """
-    Get data for ecommerce_connections. 
+    Get data for ecommerce_connections.
     Reference : https://developers.activecampaign.com/reference#list-all-connections
     """
     stream_name = 'ecommerce_connections'
-    
+
     replication_keys = ['udate']
     path = 'connections'
     data_key = 'connections'
     created_timestamp = 'cdate'
-    
+
 class EcommerceCustomers(ActiveCampaign):
     """
-    Get data for ecommerce_customers. 
+    Get data for ecommerce_customers.
     Reference : https://developers.activecampaign.com/reference#list-all-customers
     """
     stream_name = 'ecommerce_customers'
@@ -689,7 +710,7 @@ class EcommerceCustomers(ActiveCampaign):
 
 class EcommerceOrders(ActiveCampaign):
     """
-    Get data for ecommerce orders. 
+    Get data for ecommerce orders.
     Reference : https://developers.activecampaign.com/reference#list-all-customers
     """
     stream_name = 'ecommerce_orders'
@@ -702,7 +723,7 @@ class EcommerceOrders(ActiveCampaign):
 
 class EcommerceOrderProducts(ActiveCampaign):
     """
-    Get data for ecommerce order products. 
+    Get data for ecommerce order products.
     Reference : https://developers.activecampaign.com/reference#list-products-for-order
     """
     stream_name = 'ecommerce_order_products'
@@ -713,7 +734,7 @@ class EcommerceOrderProducts(ActiveCampaign):
 
 class Forms(ActiveCampaign):
     """
-    Get data for forms. 
+    Get data for forms.
     Reference : https://developers.activecampaign.com/reference#forms-1
     """
     stream_name = 'forms'
@@ -724,17 +745,17 @@ class Forms(ActiveCampaign):
 
 class Groups(ActiveCampaign):
     """
-    Get data for groups. 
+    Get data for groups.
     Reference : https://developers.activecampaign.com/reference#list-all-groups
     """
     stream_name = 'groups'
     replication_method = 'FULL_TABLE'
     path = 'groups'
     data_key = 'groups'
-    
+
 class Lists(ActiveCampaign):
     """
-    Get data for lists. 
+    Get data for lists.
     Reference : https://developers.activecampaign.com/reference#retrieve-all-lists
     """
     stream_name = 'lists'
@@ -746,7 +767,7 @@ class Lists(ActiveCampaign):
 
 class Messages(ActiveCampaign):
     """
-    Get data for messages. 
+    Get data for messages.
     Reference : https://developers.activecampaign.com/reference#list-all-messages
     """
     stream_name = 'messages'
@@ -757,29 +778,29 @@ class Messages(ActiveCampaign):
 
 class SavedResponses(ActiveCampaign):
     """
-    Get data for saved_responses. 
+    Get data for saved_responses.
     Reference : https://developers.activecampaign.com/reference#list-all-saved-responses
     """
     stream_name = 'saved_responses'
     replication_keys = ['mdate']
     path = 'savedResponses'
     data_key = 'savedResponses'
-    created_timestamp = 'cdate' 
+    created_timestamp = 'cdate'
 
 class Scores(ActiveCampaign):
     """
-    Get data for scores. 
+    Get data for scores.
     Reference : https://developers.activecampaign.com/reference#retrieve-a-score
     """
     stream_name = 'scores'
     replication_keys = ['mdate']
     path = 'scores'
     data_key = 'scores'
-    created_timestamp = 'cdate' 
+    created_timestamp = 'cdate'
 
 class Segments(ActiveCampaign):
     """
-    Get data for segments. 
+    Get data for segments.
     Reference : https://developers.activecampaign.com/reference#list-all-segments
     """
     stream_name = 'segments'
@@ -789,7 +810,7 @@ class Segments(ActiveCampaign):
 
 class Tags(ActiveCampaign):
     """
-    Get data for tags. 
+    Get data for tags.
     Reference : https://developers.activecampaign.com/reference#list-all-tags
     """
     stream_name = 'tags'
@@ -799,7 +820,7 @@ class Tags(ActiveCampaign):
 
 class TaskTypes(ActiveCampaign):
     """
-    Get data for task_types. 
+    Get data for task_types.
     Reference : https://developers.activecampaign.com/reference#list-all-deal-task-types
     """
     stream_name = 'task_types'
@@ -809,7 +830,7 @@ class TaskTypes(ActiveCampaign):
 
 class Tasks(ActiveCampaign):
     """
-    Get data for tasks. 
+    Get data for tasks.
     Reference : https://developers.activecampaign.com/reference#list-all-tasks
     """
     stream_name = 'tasks'
@@ -821,7 +842,7 @@ class Tasks(ActiveCampaign):
 
 class Templates(ActiveCampaign):
     """
-    Get data for templates. 
+    Get data for templates.
     Reference : https://developers.activecampaign.com/reference#templates
     """
     stream_name = 'templates'
@@ -831,7 +852,7 @@ class Templates(ActiveCampaign):
 
 class Users(ActiveCampaign):
     """
-    Get data for users. 
+    Get data for users.
     Reference : https://developers.activecampaign.com/reference#users
     """
     stream_name = 'users'
@@ -841,7 +862,7 @@ class Users(ActiveCampaign):
 
 class Webhooks(ActiveCampaign):
     """
-    Get data for webhooks. 
+    Get data for webhooks.
     Reference : https://developers.activecampaign.com/reference#webhooks
     """
     stream_name = 'webhooks'
@@ -853,7 +874,7 @@ class Webhooks(ActiveCampaign):
 
 class Activities(ActiveCampaign):
     """
-    Get data for activities. 
+    Get data for activities.
     """
     stream_name = 'activities'
     replication_keys = ['tstamp']
@@ -863,7 +884,7 @@ class Activities(ActiveCampaign):
 
 class AutomationBlocks(ActiveCampaign):
     """
-    Get data for automation_blocks. 
+    Get data for automation_blocks.
     """
     stream_name = 'automation_blocks'
     replication_keys = ['mdate']
@@ -873,7 +894,7 @@ class AutomationBlocks(ActiveCampaign):
 
 class BounceLogs(ActiveCampaign):
     """
-    Get data for bounce_logs. 
+    Get data for bounce_logs.
     """
     stream_name = 'bounce_logs'
     replication_keys = ['updated_timestamp']
@@ -883,7 +904,7 @@ class BounceLogs(ActiveCampaign):
 
 class CampaignLists(ActiveCampaign):
     """
-    Get data for campaign_lists. 
+    Get data for campaign_lists.
     """
     stream_name = 'campaign_lists'
     replication_method = 'FULL_TABLE'
@@ -892,16 +913,16 @@ class CampaignLists(ActiveCampaign):
 
 class CampaignMessages(ActiveCampaign):
     """
-    Get data for campaign_messages. 
+    Get data for campaign_messages.
     """
     stream_name = 'campaign_messages'
     replication_method = 'FULL_TABLE'
     path = 'campaignMessages'
     data_key = 'campaignMessages'
-    
+
 class Configs(ActiveCampaign):
     """
-    Get data for configs. 
+    Get data for configs.
     """
     stream_name = 'configs'
     replication_keys = ['updated_timestamp']
@@ -911,7 +932,7 @@ class Configs(ActiveCampaign):
 
 class ContactData(ActiveCampaign):
     """
-    Get data for contact_data. 
+    Get data for contact_data.
     """
     stream_name = 'contact_data'
     replication_keys = ['tstamp']
@@ -920,7 +941,7 @@ class ContactData(ActiveCampaign):
 
 class ContactEmails(ActiveCampaign):
     """
-    Get data for contact_emails. 
+    Get data for contact_emails.
     """
     stream_name = 'contact_emails'
     replication_keys = ['sdate']
@@ -930,7 +951,7 @@ class ContactEmails(ActiveCampaign):
 
 class ContactLists(ActiveCampaign):
     """
-    Get data for contact_lists. 
+    Get data for contact_lists.
     """
     stream_name = 'contact_lists'
     replication_keys = ['updated_timestamp']
@@ -940,7 +961,7 @@ class ContactLists(ActiveCampaign):
 
 class ContactTags(ActiveCampaign):
     """
-    Get data for contact_tags. 
+    Get data for contact_tags.
     """
     stream_name = 'contact_tags'
     replication_keys = ['updated_timestamp']
@@ -950,7 +971,7 @@ class ContactTags(ActiveCampaign):
 
 class ContactConversions(ActiveCampaign):
     """
-    Get data for contact_conversions. 
+    Get data for contact_conversions.
     """
     stream_name = 'contact_conversions'
     replication_keys = ['cdate']
@@ -959,7 +980,7 @@ class ContactConversions(ActiveCampaign):
 
 class Conversions(ActiveCampaign):
     """
-    Get data for conversions. 
+    Get data for conversions.
     """
     stream_name = 'conversions'
     replication_keys = ['udate']
@@ -967,10 +988,10 @@ class Conversions(ActiveCampaign):
     data_key = 'conversions'
     created_timestamp = 'cdate'
     links= ['contactConversions']
- 
+
 class ConversionTriggers(ActiveCampaign):
     """
-    Get data for conversion_triggers. 
+    Get data for conversion_triggers.
     """
     stream_name = 'conversion_triggers'
     replication_keys = ['udate']
@@ -980,7 +1001,7 @@ class ConversionTriggers(ActiveCampaign):
 
 class DealActivities(ActiveCampaign):
     """
-    Get data for deal_activities. 
+    Get data for deal_activities.
     """
     stream_name = 'deal_activities'
     replication_keys = ['cdate']
@@ -989,7 +1010,7 @@ class DealActivities(ActiveCampaign):
 
 class DealGroupUsers(ActiveCampaign):
     """
-    Get data for deal_group_users. 
+    Get data for deal_group_users.
     """
     stream_name = 'deal_group_users'
     replication_method = 'FULL_TABLE'
@@ -998,7 +1019,7 @@ class DealGroupUsers(ActiveCampaign):
 
 class EcommerceOrderActivities(ActiveCampaign):
     """
-    Get data for ecommerce_order_activities. 
+    Get data for ecommerce_order_activities.
     """
     stream_name = 'ecommerce_order_activities'
     replication_keys = ['updated_date']
@@ -1008,7 +1029,7 @@ class EcommerceOrderActivities(ActiveCampaign):
 
 class EmailActivities(ActiveCampaign):
     """
-    Get data for email_activities. 
+    Get data for email_activities.
     """
     stream_name = 'email_activities'
     replication_keys = ['tstamp']
@@ -1017,7 +1038,7 @@ class EmailActivities(ActiveCampaign):
 
 class Goals(ActiveCampaign):
     """
-    Get data for goals. 
+    Get data for goals.
     """
     stream_name = 'goals'
     replication_method = 'FULL_TABLE'
@@ -1026,7 +1047,7 @@ class Goals(ActiveCampaign):
 
 class SiteMessages(ActiveCampaign):
     """
-    Get data for site_messages. 
+    Get data for site_messages.
     """
     stream_name = 'site_messages'
     replication_keys = ['ldate']
@@ -1035,7 +1056,7 @@ class SiteMessages(ActiveCampaign):
 
 class Sms(ActiveCampaign):
     """
-    Get data for sms. 
+    Get data for sms.
     """
     stream_name = 'sms'
     replication_keys = ['tstamp']

--- a/tap_activecampaign/transform.py
+++ b/tap_activecampaign/transform.py
@@ -1,4 +1,3 @@
-import re
 import humps
 import singer
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -10,7 +10,7 @@ import pytz
 
 class ActiveCampaignTest(unittest.TestCase):
     start_date = ""
-    
+
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
     PRIMARY_KEYS = "table-key-properties"
     REPLICATION_METHOD = "forced-replication-method"
@@ -24,7 +24,7 @@ class ActiveCampaignTest(unittest.TestCase):
     def tap_name(self):
         """The name of the tap"""
         return "tap-activecampaign"
-    
+
     def setUp(self):
         required_env = {
             "TAP_ACTIVECAMPAIGN_API_TOKEN",
@@ -33,7 +33,7 @@ class ActiveCampaignTest(unittest.TestCase):
         missing_envs = [v for v in required_env if not os.getenv(v)]
         if missing_envs:
             raise Exception("set " + ", ".join(missing_envs))
-        
+
     def get_type(self):
         return "platform.activecampaign"
 
@@ -55,7 +55,7 @@ class ActiveCampaignTest(unittest.TestCase):
         # Reassign start date
         return_value["start_date"] = self.start_date
         return return_value
-    
+
     def expected_metadata(self):
         """The expected streams and metadata about the streams"""
         return {
@@ -69,7 +69,7 @@ class ActiveCampaignTest(unittest.TestCase):
                 self.PRIMARY_KEYS: {'id'},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {'updated_timestamp'},
-                self.OBEYS_START_DATE: True      
+                self.OBEYS_START_DATE: True
             },
             'account_custom_fields': {
                 self.PRIMARY_KEYS: {'id'},
@@ -576,7 +576,7 @@ class ActiveCampaignTest(unittest.TestCase):
         date_object = dateutil.parser.parse(date_str)
         date_object_utc = date_object.astimezone(tz=pytz.UTC)
         return dt.strftime(date_object_utc, "%Y-%m-%dT%H:%M:%SZ")
-    
+
     def timedelta_formatted(self, dtime, days=0):
         try:
             date_stripped = dt.strptime(dtime, self.START_DATE_FORMAT)
@@ -607,7 +607,7 @@ class ActiveCampaignTest(unittest.TestCase):
 
         raise NotImplementedError(
             "Tests do not account for dates of this format: {}".format(date_value))
-    
+
     @staticmethod
     def assertIsDateFormat(value, str_format):
         """Assertion Method that verifies a string value is a formatted

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -24,21 +24,33 @@ class ActiveCampaignAllFields(ActiveCampaignTest):
         • verify all fields for each stream are replicated
         """
 
-
         # Streams to verify all fields tests
         expected_streams = self.expected_check_streams()
 
-        # We are not able to generate data for `contact_conversions` stream.
         # For `sms` stream it requires Professional plan of account. So, removing it from streams_to_test set.
         # BUG TDL-26417: Skip 'bounce_logs'
         # Streams that cannot have data generated
         streams_to_skip = {
-            'bounce_logs', 'contact_conversions', 'sms',
-            'contact_automations',
-            'goals', 'contact_data', 'contact_emails',
-            'email_activities', 'site_messages'
+            'addresses',
+            'bounce_logs',
+            'campaign_links',
+            'contact_deals',
+            'contact_emails',
+            'deal_group_users',
+            'deal_stages',
+            'ecommerce_connections',
+            'ecommerce_customers',
+            'ecommerce_order_activities',
+            'ecommerce_order_products',
+            'ecommerce_orders',
+            'email_activities',
+            'goals',
+            'site_messages',
+            'sms',
+            'templates',
+            'webhooks',
         }
-        
+
         expected_streams = expected_streams - streams_to_skip
 
         expected_automatic_fields = self.expected_automatic_fields()

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -7,7 +7,7 @@ class ActiveCampaignAutomaticFields(ActiveCampaignTest):
     Ensure running the tap with all streams selected and all fields deselected results in the replication of just the 
     primary keys and replication keys (automatic fields).
     """
-    
+
     def name(self):
         return "activecampaign_automatic_fields"
 
@@ -17,20 +17,35 @@ class ActiveCampaignAutomaticFields(ActiveCampaignTest):
         Verify that only the automatic fields are sent to the target.
         Verify that all replicated records have unique primary key values.
         """
-        
+
         streams_to_test = self.expected_check_streams()
 
-        # We are not able to generate data for `contact_conversions` stream.
         # For `sms` it requires Enterprise plan of account. So, removing it from streams_to_test set.
         # Streams that cannot have data generated
         streams_to_skip = {
-            'contact_conversions', 'bounce_logs',
-            'contact_automations', 'goals', 'sms',
-            'contact_data', 'contact_emails',
-            'email_activities', 'site_messages'
+            'activities',
+            'addresses',
+            'bounce_logs',
+            'campaign_links',
+            'contact_deals',
+            'contact_emails',
+            'deals',
+            'deal_group_users',
+            'deal_stages',
+            'ecommerce_connections',
+            'ecommerce_customers',
+            'ecommerce_order_activities',
+            'ecommerce_order_products',
+            'ecommerce_orders',
+            'email_activities',
+            'goals',
+            'site_messages',
+            'sms',
+            'templates',
+            'webhooks',
         }
         streams_to_test = streams_to_test - streams_to_skip
-        
+
         conn_id = connections.ensure_connection(self)
 
         found_catalogs = self.run_and_verify_check_mode(conn_id)
@@ -45,14 +60,14 @@ class ActiveCampaignAutomaticFields(ActiveCampaignTest):
 
         record_count_by_stream = self.run_and_verify_sync(conn_id)
         synced_records = runner.get_records_from_target_output()
-        
+
         for stream in streams_to_test:
             with self.subTest(stream=stream):
 
                 # expected values
                 expected_keys = self.expected_automatic_fields().get(stream)
                 expected_primary_keys = self.expected_primary_keys()[stream]
-                
+
                 # collect actual values
                 data = synced_records.get(stream, {})
                 record_messages_keys = [set(row['data'].keys())
@@ -61,7 +76,7 @@ class ActiveCampaignAutomaticFields(ActiveCampaignTest):
                                        for message in data.get('messages', [])
                                        if message.get('action') == 'upsert']
                 unique_primary_keys_list = set(primary_keys_list)
-                
+
                 # Verify that you get some records for each stream
                 self.assertGreater(
                     record_count_by_stream.get(stream, -1), 0,
@@ -70,8 +85,8 @@ class ActiveCampaignAutomaticFields(ActiveCampaignTest):
                 # Verify that only the automatic fields are sent to the target
                 for actual_keys in record_messages_keys:
                     self.assertSetEqual(expected_keys, actual_keys)
-                    
+
                 #Verify that all replicated records have unique primary key values.
-                self.assertEqual(len(primary_keys_list), 
-                                    len(unique_primary_keys_list), 
+                self.assertEqual(len(primary_keys_list),
+                                    len(unique_primary_keys_list),
                                     msg="Replicated record does not have unique primary key values.")

--- a/tests/test_bookmark.py
+++ b/tests/test_bookmark.py
@@ -5,7 +5,7 @@ from tap_tester import menagerie
 
 class ActiveCampaignBookMark(ActiveCampaignTest):
     """Test tap sets a bookmark and respects it for the next sync of a stream"""
-    
+
     def name(self):
         return "activecampaign_bookmark_test"
 
@@ -24,18 +24,31 @@ class ActiveCampaignBookMark(ActiveCampaignTest):
         For EACH stream that is incrementally replicated there are multiple rows of data with
             different values for the replication key
         """
-        
-        
+
+
         expected_streams = self.expected_check_streams()
-        # We are not able to generate data for `contact_conversions` stream.
         # For `sms` stream it requires Enterprise plan of account. So, removing it from expected_streams set.
         # BUG TDL-26417: Skip 'bounce_logs'
         # Streams that cannot have data generated
         streams_to_skip = {
-            'bounce_logs', 'contact_conversions', 'sms',
-            'contact_automations',
-            'goals', 'contact_data', 'contact_emails',
-            'email_activities', 'site_messages'
+            'addresses',
+            'bounce_logs',
+            'campaign_links',
+            'contact_deals',
+            'contact_emails',
+            'deal_group_users',
+            'deal_stages',
+            'ecommerce_connections',
+            'ecommerce_customers',
+            'ecommerce_order_activities',
+            'ecommerce_order_products',
+            'ecommerce_orders',
+            'email_activities',
+            'goals',
+            'site_messages',
+            'sms',
+            'templates',
+            'webhooks',
         }
         expected_streams = expected_streams - streams_to_skip
 
@@ -118,7 +131,7 @@ class ActiveCampaignBookMark(ActiveCampaignTest):
                     self.assertIsInstance(second_bookmark_value, str)
                     self.assertIsDateFormat(first_bookmark_value, self.BOOKMARK_COMPARISON_FORMAT)
                     self.assertIsDateFormat(second_bookmark_value, self.BOOKMARK_COMPARISON_FORMAT)
-                    
+
                     # Verify the first sync sets a bookmark of the expected form
                     self.assertIsNotNone(first_bookmark_value)
 
@@ -138,7 +151,7 @@ class ActiveCampaignBookMark(ActiveCampaignTest):
                             replication_key_value, first_bookmark_value,
                             msg="First sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
                         )
-                    
+
                     for record in second_sync_messages:
                         # Verify the second sync replication key value is Greater or Equal to the first sync bookmark
                         replication_key_value = record.get(replication_key)

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -38,7 +38,7 @@ class ActiveCampaignDiscover(ActiveCampaignTest):
         found_catalog_names = {c['tap_stream_id'] for c in found_catalogs}
         self.assertTrue(all([re.fullmatch(r"[a-z_]+",  name) for name in found_catalog_names]),
                         msg="One or more streams don't follow standard naming")
-        
+
         for stream in streams_to_test:
             with self.subTest(stream=stream):
 
@@ -59,10 +59,10 @@ class ActiveCampaignDiscover(ActiveCampaignTest):
                 schema_and_metadata = menagerie.get_annotated_schema(
                     conn_id, catalog['stream_id'])
                 metadata = schema_and_metadata["metadata"]
-                
+
                 stream_properties = [
                     item for item in metadata if item.get("breadcrumb") == []]
-                
+
                 actual_primary_keys = set(
                     stream_properties[0].get(
                         "metadata", {self.PRIMARY_KEYS: []}).get(self.PRIMARY_KEYS, [])
@@ -77,7 +77,7 @@ class ActiveCampaignDiscover(ActiveCampaignTest):
                     item.get("breadcrumb", ["properties", None])[1] for item in metadata
                     if item.get("metadata").get("inclusion") == "automatic"
                 )
-                
+
                 actual_fields = []
                 for md_entry in metadata:
                     if md_entry['breadcrumb'] != []:
@@ -99,7 +99,7 @@ class ActiveCampaignDiscover(ActiveCampaignTest):
                 self.assertSetEqual(
                     expected_primary_keys, actual_primary_keys,
                 )
-                
+
                 # verify that primary keys and replication keys
                 # are given the inclusion of automatic in metadata.
                 self.assertSetEqual(expected_automatic_fields,

--- a/tests/test_interrupted_sync.py
+++ b/tests/test_interrupted_sync.py
@@ -47,14 +47,27 @@ class InterruptedSyncTest(ActiveCampaignTest):
 
         conn_id = connections.ensure_connection(self)
 
-        # Note: test data not available for following streams: contact_conversions, sms
         # BUG TDL-26417: Skip 'bounce_logs'
         # Streams that cannot have data generated
         streams_to_skip = {
-            'bounce_logs', 'contact_conversions', 'sms',
-            'contact_automations',
-            'goals', 'contact_data', 'contact_emails',
-            'email_activities', 'site_messages'
+            'addresses',
+            'bounce_logs',
+            'campaign_links',
+            'contact_deals',
+            'contact_emails',
+            'deal_group_users',
+            'deal_stages',
+            'ecommerce_connections',
+            'ecommerce_customers',
+            'ecommerce_order_activities',
+            'ecommerce_order_products',
+            'ecommerce_orders',
+            'email_activities',
+            'goals',
+            'site_messages',
+            'sms',
+            'templates',
+            'webhooks',
         }
         streams_to_test = self.expected_check_streams() - streams_to_skip
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,6 +1,5 @@
 import tap_tester.connections as connections
 import tap_tester.runner as runner
-import tap_tester.menagerie as menagerie
 from base import ActiveCampaignTest
 
 
@@ -14,7 +13,7 @@ class ActiveCampaignPagination(ActiveCampaignTest):
 
     def test_run(self):
         """
-        • Verify that for each stream you can get multiple pages of data.  
+        • Verify that for each stream you can get multiple pages of data.
         This requires we ensure more than 1 page of data exists at all times for any given stream.
         • Verify by pks that the data replicated matches the data we expect.
         """
@@ -23,27 +22,61 @@ class ActiveCampaignPagination(ActiveCampaignTest):
         expected_streams = self.expected_check_streams()
 
         # We are not able to generate enough data to test pagination for below streams,
-        # `brandings`, `configs`, `conversions`, `conversion_triggers`, `goals`, `contact_conversions`, `sms`, `user`.
-        # The current plan allows only 25 users. So, skipped `user` stream. sms feature is not supported for the current plan.
+        # `brandings`, `configs`, `conversions`, `conversion_triggers`, `goals`, `sms`, `users`.
+        # The current plan allows only 25 users. So, skipped `users` stream. sms feature is not supported for the current plan.
         # So, removing it all from expected_streams set.
         # BUG TDL-26417: Skip 'bounce_logs'
         # Streams that cannot have data generated
         streams_to_skip = {
-            'bounce_logs', 'contact_conversions', 'sms', 'users',
-            'brandings', 'configs', 'conversions', 'conversion_triggers', 'goals',
-            'automations', 'automation_blocks', 'contact_automations',
-            'contact_data', 'contact_emails', 'email_activities', 'site_messages',
-            'accounts', 'account_contacts', 'account_custom_fields',
-            'account_custom_field_values', 'activities', 'addresses',
-            'calendars', 'campaigns', 'campaign_links', 'campaign_lists',
-            'campaign_messages', 'contact_custom_fields', 'contact_custom_field_options',
-            'contact_custom_field_rels', 'contact_custom_field_values',
-            'contact_deals', 'deal_custom_fields', 'deal_custom_field_values',
-            'deal_group_users', 'deal_groups', 'deal_stages',
-            'ecommerce_connections', 'ecommerce_customers', 'ecommerce_orders',
-            'ecommerce_order_activities', 'ecommerce_order_products',
-            'forms', 'groups', 'lists', 'messages', 'saved_responses',
-            'scores', 'segments', 'task_types', 'tasks', 'webhooks'
+            'account_custom_fields',
+            'account_custom_field_values',
+            'addresses',
+            'automation_blocks',
+            'automations',
+            'bounce_logs',
+            'brandings',
+            'calendars',
+            'campaign_links',
+            'campaign_lists',
+            'campaign_messages',
+            'campaigns',
+            'configs',
+            'contact_automations',
+            'contact_custom_field_rels',
+            'contact_custom_fields',
+            'contact_custom_field_options',
+            'contact_data',
+            'contact_deals',
+            'contact_emails',
+            'conversion_triggers',
+            'conversions',
+            'deals',
+            'deal_custom_fields',
+            'deal_group_users',
+            'deal_groups',
+            'deal_stages',
+            'ecommerce_connections',
+            'ecommerce_customers',
+            'ecommerce_order_activities',
+            'ecommerce_order_products',
+            'ecommerce_orders',
+            'email_activities',
+            'forms',
+            'goals',
+            'groups',
+            'lists',
+            'messages',
+            'saved_responses',
+            'scores',
+            'segments',
+            'site_messages',
+            'sms',
+            'tags',
+            'task_types',
+            'tasks',
+            'templates',
+            'users',
+            'webhooks',
         }
         expected_streams = expected_streams - streams_to_skip
 

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -16,6 +16,18 @@ class ActiveCampaignStartDate(ActiveCampaignTest):
     def name(self):
         return "activecampaign_start_date_test"
 
+    def get_properties(self, original: bool = True):
+        """Override start date to fall within actual test data range.
+        start_date_1 = 2026-06-14, start_date_2 = 2026-06-18 (days=4), splitting
+        data that spans 2026-06-15 through 2026-06-19."""
+        return_value = {
+            "start_date": "2026-06-14T00:00:00Z",
+        }
+        if original:
+            return return_value
+        return_value["start_date"] = self.start_date
+        return return_value
+
     def test_run(self):
         """
         Test that the start_date configuration is respected

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -1,21 +1,21 @@
 import tap_tester.connections as connections
 import tap_tester.runner as runner
 from base import ActiveCampaignTest
-from datetime import datetime
+
 
 class ActiveCampaignStartDate(ActiveCampaignTest):
     """
-    Ensure both all expected streams respect the start date. Run tap in check mode, 
+    Ensure both all expected streams respect the start date. Run tap in check mode,
     run 1st sync with start date = 2021-11-10, run check mode and 2nd sync on a new connection with start date = 13 days later.
     """
 
-    
+
     start_date_1 = ""
     start_date_2 = ""
 
     def name(self):
         return "activecampaign_start_date_test"
-        
+
     def test_run(self):
         """
         Test that the start_date configuration is respected
@@ -27,26 +27,60 @@ class ActiveCampaignStartDate(ActiveCampaignTest):
         # Streams to verify start date tests
         expected_streams = self.expected_check_streams()
 
-        # We are not able to generate data for `contact_conversions`stream. 
+        # We are not able to generate data for `contact_conversions`stream.
         # For `sms` stream it requires Enterprise plan of account. So, removing it from streams_to_test set.
         # BUG TDL-26417: Skip 'bounce_logs'
         # Streams that cannot have data generated
         expected_streams = expected_streams - {
-            'bounce_logs', 'contact_conversions', 'sms',
+            'accounts',
+            'account_contacts',
+            'account_custom_fields',
+            'account_custom_field_values',
+            'activities',
+            'addresses',
+            'automations',
+            'automation_blocks',
+            'brandings',
+            'bounce_logs',
+            'calendars',
+            'campaigns',
+            'campaign_links',
+            'contacts',
             'contact_automations',
-            'goals', 'contact_data', 'contact_emails',
-            'email_activities', 'site_messages',
-            'contacts', 'saved_responses', 'contact_custom_field_values',
-            'contact_deals', 'deal_custom_field_values', 'deal_groups',
-            'deal_stages', 'deals', 'ecommerce_connections',
-            'ecommerce_customers', 'ecommerce_orders', 'ecommerce_order_activities',
-            'calendars', 'campaigns', 'accounts', 'contact_tags', 'account_contacts',
-            'automations', 'deal_activities', 'campaign_links', 'automation_blocks',
-            'ecommerce_connections', 'tasks', 'account_custom_field_values', 'forms'
+            'contact_conversions',
+            'contact_data',
+            'contact_deals',
+            'contact_tags',
+            'contact_custom_field_values',
+            'conversions',
+            'contact_emails',
+            'conversion_triggers',
+            'deals',
+            'deal_activities',
+            'deal_custom_fields',
+            'deal_custom_field_values',
+            'deal_group_users',
+            'deal_groups',
+            'deal_stages',
+            'email_activities',
+            'ecommerce_connections',
+            'ecommerce_connections',
+            'ecommerce_customers',
+            'ecommerce_orders',
+            'ecommerce_order_activities',
+            'forms',
+            'goals',
+            'lists',
+            'sms',
+            'site_messages',
+            'saved_responses',
+            'tasks',
+            'templates',
+            'webhooks',
         }
 
         self.run_test(days=4, expected_streams=expected_streams)
-        
+
     def run_test(self, days, expected_streams):
         self.start_date_1 = self.get_properties().get('start_date')
         self.start_date_2 = self.timedelta_formatted(self.start_date_1, days=days)
@@ -75,7 +109,7 @@ class ActiveCampaignStartDate(ActiveCampaignTest):
         ##########################################################################
         # Update START DATE Between Syncs
         ##########################################################################
-        
+
         print("REPLICATION START DATE CHANGE: {} ===>>> {} ".format(
             self.start_date, self.start_date_2))
         self.start_date = self.start_date_2
@@ -163,7 +197,7 @@ class ActiveCampaignStartDate(ActiveCampaignTest):
                     self.assertTrue(
                         primary_keys_sync_2.issubset(primary_keys_sync_1))
                 else:
-                    
+
                     # Verify that the 2nd sync with a later start date replicates the same number of
                     # records as the 1st sync.
 

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,11 +1,15 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from tap_activecampaign.exceptions import ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError
-from tap_activecampaign.discover import (
-    check_stream_access,
-    _get_accessible_streams,
-    discover,
+from tap_activecampaign.exceptions import (
+    ActiveCampaignForbiddenError,
+    ActiveCampaignUnauthorizedError,
     ActiveCampaignDiscoveryForbiddenError,
+)
+from tap_activecampaign.streams import ActiveCampaign
+from tap_activecampaign.discover import (
+    _prune_inaccessible_children,
+    _apply_access_checks,
+    discover,
 )
 
 
@@ -25,150 +29,233 @@ def _make_client(side_effect=None, return_value=None):
     return client
 
 
-def _make_stream_cls(path):
-    """Return a minimal mock stream class with a path attribute."""
-    cls = MagicMock()
-    cls.path = path
+def _make_stream_instance(stream_name, path, parent=None, client=None):
+    """Return an ActiveCampaign base instance with the given attributes set."""
+    instance = ActiveCampaign(client=client or _make_client())
+    instance.stream_name = stream_name
+    instance.path = path
+    instance.parent = parent
+    return instance
+
+
+def _make_stream_cls(parent=None, accessible=True):
+    """Return a mock stream *class* with a .parent attribute and check_access() behaviour."""
+    inst = MagicMock()
+    inst.check_access.return_value = accessible
+    inst.parent = parent
+    cls = MagicMock(return_value=inst)
+    cls.parent = parent
     return cls
 
 
 # ---------------------------------------------------------------------------
-# TestCheckStreamAccess
+# TestCheckAccess
 # ---------------------------------------------------------------------------
 
-class TestCheckStreamAccess(unittest.TestCase):
-    """Unit tests for check_stream_access()."""
+class TestCheckAccess(unittest.TestCase):
+    """Unit tests for ActiveCampaign.check_access()."""
 
     def test_returns_true_when_accessible(self):
         """A successful GET returns True."""
-        client = _make_client(return_value={'contacts': []})
-        result = check_stream_access(client, 'contacts', 'contacts')
-        self.assertTrue(result)
-        client.get.assert_called_once_with(path='contacts', params={'limit': 1}, endpoint='contacts')
+        client = _make_client(return_value={})
+        stream = _make_stream_instance('contacts', 'contacts', client=client)
+        self.assertTrue(stream.check_access())
+        client.get.assert_called_once_with(
+            path='contacts', params={'limit': 1}, endpoint='contacts'
+        )
+
+    def test_child_stream_always_returns_true_without_calling_api(self):
+        """Child streams always return True; the API is never called."""
+        client = _make_client()
+        stream = _make_stream_instance(
+            'ecommerce_order_products',
+            'ecomOrders/{}/orderProducts',
+            parent='ecommerce_orders',
+            client=client,
+        )
+        self.assertTrue(stream.check_access())
+        client.get.assert_not_called()
 
     def test_returns_false_on_forbidden_error(self):
         """A 403 ForbiddenError returns False without re-raising."""
         client = _make_client(side_effect=ActiveCampaignForbiddenError('403 Forbidden'))
-        result = check_stream_access(client, 'contacts', 'contacts')
-        self.assertFalse(result)
+        stream = _make_stream_instance('contacts', 'contacts', client=client)
+        self.assertFalse(stream.check_access())
 
     def test_returns_false_on_unauthorized_error(self):
         """A 401 UnauthorizedError returns False without re-raising."""
         client = _make_client(side_effect=ActiveCampaignUnauthorizedError('401 Unauthorized'))
-        result = check_stream_access(client, 'contacts', 'contacts')
-        self.assertFalse(result)
+        stream = _make_stream_instance('contacts', 'contacts', client=client)
+        self.assertFalse(stream.check_access())
 
     def test_reraises_unexpected_exception(self):
-        """Any other exception is re-raised to the caller."""
-        client = _make_client(side_effect=RuntimeError('unexpected'))
+        """Non-auth exceptions are re-raised to the caller."""
+        client = _make_client(side_effect=RuntimeError('network failure'))
+        stream = _make_stream_instance('contacts', 'contacts', client=client)
         with self.assertRaises(RuntimeError):
-            check_stream_access(client, 'contacts', 'contacts')
+            stream.check_access()
+
+    def test_warning_logged_on_forbidden(self):
+        """A WARNING is emitted containing the stream name when access is denied."""
+        client = _make_client(side_effect=ActiveCampaignForbiddenError('403'))
+        stream = _make_stream_instance('contacts', 'contacts', client=client)
+        with patch('tap_activecampaign.streams.LOGGER') as mock_logger:
+            stream.check_access()
+            mock_logger.warning.assert_called_once()
+            self.assertIn('contacts', mock_logger.warning.call_args[0][1])
 
 
 # ---------------------------------------------------------------------------
-# TestGetAccessibleStreams
+# TestPruneInaccessibleChildren
 # ---------------------------------------------------------------------------
 
-# Minimal schema fixture: two parent streams + one child stream
-SCHEMAS = {
-    'stream_a': {'type': 'object', 'properties': {}},
-    'stream_b': {'type': 'object', 'properties': {}},
-    'child_of_a': {'type': 'object', 'properties': {}},
-}
-
-FLAT_STREAMS = {
-    'stream_a':   {'key_properties': ['id'], 'parent_tap_stream_id': None},
-    'stream_b':   {'key_properties': ['id'], 'parent_tap_stream_id': None},
-    'child_of_a': {'key_properties': ['id'], 'parent_tap_stream_id': 'stream_a'},
-}
-
-MOCK_STREAMS = {
-    'stream_a':   _make_stream_cls('path/a'),
-    'stream_b':   _make_stream_cls('path/b'),
-    'child_of_a': _make_stream_cls('path/a/{}/child'),
+_MOCK_STREAMS_PRUNE = {
+    'parent_a': _make_stream_cls(parent=None),
+    'parent_b': _make_stream_cls(parent=None),
+    'child_of_a': _make_stream_cls(parent='parent_a'),
+    'child_of_b': _make_stream_cls(parent='parent_b'),
 }
 
 
-@patch('tap_activecampaign.discover.STREAMS', MOCK_STREAMS)
-class TestGetAccessibleStreams(unittest.TestCase):
-    """Unit tests for _get_accessible_streams()."""
+@patch('tap_activecampaign.discover.STREAMS', _MOCK_STREAMS_PRUNE)
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Unit tests for _prune_inaccessible_children(schemas, field_metadata)."""
 
-    def test_all_parent_streams_accessible(self):
-        """Returns all schemas (including child) when all parent streams are accessible."""
-        client = _make_client(return_value={})
-        result = _get_accessible_streams(client, SCHEMAS, FLAT_STREAMS)
-        self.assertEqual(set(result.keys()), {'stream_a', 'stream_b', 'child_of_a'})
+    def test_child_included_when_parent_accessible(self):
+        """Child stays in schemas when its parent is still present."""
+        schemas = {'parent_a': {}, 'parent_b': {}, 'child_of_a': {}, 'child_of_b': {}}
+        field_metadata = {'parent_a': [], 'parent_b': [], 'child_of_a': [], 'child_of_b': []}
+        _prune_inaccessible_children(schemas, field_metadata)
+        self.assertIn('child_of_a', schemas)
+        self.assertIn('child_of_b', schemas)
 
-    def test_child_stream_not_probed(self):
-        """Child streams are skipped during probing (their path requires a parent id)."""
-        client = _make_client(return_value={})
-        _get_accessible_streams(client, SCHEMAS, FLAT_STREAMS)
-        probe_paths = [c.kwargs.get('path') or c.args[0] for c in client.get.call_args_list]
-        self.assertNotIn('path/a/{}/child', probe_paths)
+    def test_child_excluded_when_parent_already_popped(self):
+        """Child is popped from schemas and field_metadata when its parent is absent."""
+        # Simulate parent_a already removed by _apply_access_checks
+        schemas = {'parent_b': {}, 'child_of_a': {}, 'child_of_b': {}}
+        field_metadata = {'parent_b': [], 'child_of_a': [], 'child_of_b': []}
+        _prune_inaccessible_children(schemas, field_metadata)
+        self.assertNotIn('child_of_a', schemas)
+        self.assertNotIn('child_of_a', field_metadata)
+        self.assertIn('child_of_b', schemas)
 
-    def test_inaccessible_parent_excluded_from_catalog(self):
-        """An inaccessible parent stream is removed from the returned schemas."""
-        def selective_forbidden(path, **kwargs):
-            if path == 'path/b':
-                raise ActiveCampaignForbiddenError('403')
-            return {}
-        client = _make_client(side_effect=selective_forbidden)
-        result = _get_accessible_streams(client, SCHEMAS, FLAT_STREAMS)
-        self.assertNotIn('stream_b', result)
-        self.assertIn('stream_a', result)
+    def test_warning_logged_for_excluded_child(self):
+        """A WARNING names both the excluded child and the inaccessible parent."""
+        schemas = {'parent_b': {}, 'child_of_a': {}, 'child_of_b': {}}
+        field_metadata = {'parent_b': [], 'child_of_a': [], 'child_of_b': []}
+        with patch('tap_activecampaign.discover.LOGGER') as mock_logger:
+            _prune_inaccessible_children(schemas, field_metadata)
+            mock_logger.warning.assert_called_once()
+            args = mock_logger.warning.call_args[0]
+            self.assertIn('child_of_a', args[1])
+            self.assertIn('parent_a', args[2])
+
+    def test_no_warning_when_all_parents_accessible(self):
+        """No WARNING is emitted when every parent is present in schemas."""
+        schemas = {'parent_a': {}, 'parent_b': {}, 'child_of_a': {}, 'child_of_b': {}}
+        field_metadata = {'parent_a': [], 'parent_b': [], 'child_of_a': [], 'child_of_b': []}
+        with patch('tap_activecampaign.discover.LOGGER') as mock_logger:
+            _prune_inaccessible_children(schemas, field_metadata)
+            mock_logger.warning.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestApplyAccessChecks
+# ---------------------------------------------------------------------------
+
+_MOCK_STREAMS_APPLY = {
+    'stream_a': _make_stream_cls(parent=None, accessible=True),
+    'stream_b': _make_stream_cls(parent=None, accessible=True),
+}
+
+
+@patch('tap_activecampaign.discover.STREAMS', _MOCK_STREAMS_APPLY)
+class TestApplyAccessChecks(unittest.TestCase):
+    """Unit tests for _apply_access_checks(client, schemas, field_metadata)."""
+
+    def _schemas_and_meta(self, names):
+        return {n: {} for n in names}, {n: [] for n in names}
+
+    def test_accessible_streams_remain_in_schemas(self):
+        """All streams stay in schemas when all return check_access() == True."""
+        schemas, field_metadata = self._schemas_and_meta(['stream_a', 'stream_b'])
+        _apply_access_checks(_make_client(), schemas, field_metadata)
+        self.assertIn('stream_a', schemas)
+        self.assertIn('stream_b', schemas)
+
+    def test_inaccessible_stream_popped_from_schemas(self):
+        """Inaccessible stream is removed from both schemas and field_metadata."""
+        mock_streams = {
+            'stream_a': _make_stream_cls(parent=None, accessible=False),
+            'stream_b': _make_stream_cls(parent=None, accessible=True),
+        }
+        schemas, field_metadata = self._schemas_and_meta(['stream_a', 'stream_b'])
+        with patch('tap_activecampaign.discover.STREAMS', mock_streams):
+            _apply_access_checks(_make_client(), schemas, field_metadata)
+        self.assertNotIn('stream_a', schemas)
+        self.assertNotIn('stream_a', field_metadata)
+        self.assertIn('stream_b', schemas)
+
+    def test_all_inaccessible_raises_forbidden(self):
+        """Raises ActiveCampaignDiscoveryForbiddenError when all parent streams are inaccessible."""
+        mock_streams = {
+            'stream_a': _make_stream_cls(parent=None, accessible=False),
+            'stream_b': _make_stream_cls(parent=None, accessible=False),
+        }
+        schemas, field_metadata = self._schemas_and_meta(['stream_a', 'stream_b'])
+        with patch('tap_activecampaign.discover.STREAMS', mock_streams):
+            with self.assertRaises(ActiveCampaignDiscoveryForbiddenError):
+                _apply_access_checks(_make_client(), schemas, field_metadata)
 
     def test_child_excluded_when_parent_inaccessible(self):
-        """Child stream is excluded when its parent is inaccessible."""
-        def block_stream_a(path, **kwargs):
-            if path == 'path/a':
-                raise ActiveCampaignForbiddenError('403')
-            return {}
-        client = _make_client(side_effect=block_stream_a)
-        result = _get_accessible_streams(client, SCHEMAS, FLAT_STREAMS)
-        self.assertNotIn('stream_a', result)
-        self.assertNotIn('child_of_a', result)
-        self.assertIn('stream_b', result)
-
-    def test_warning_logged_for_inaccessible_streams(self):
-        """A warning is logged listing the inaccessible streams."""
-        schemas_two = {'stream_a': SCHEMAS['stream_a'], 'stream_b': SCHEMAS['stream_b']}
-        flat_two = {'stream_a': FLAT_STREAMS['stream_a'], 'stream_b': FLAT_STREAMS['stream_b']}
-
-        def block_a_only(path, **kwargs):
-            if path == 'path/a':
-                raise ActiveCampaignForbiddenError('403')
-            return {}
-
-        client = _make_client(side_effect=block_a_only)
-        with patch('tap_activecampaign.discover.LOGGER') as mock_logger:
-            _get_accessible_streams(client, schemas_two, flat_two)
-            warning_call = mock_logger.warning.call_args
-            self.assertIn('stream_a', warning_call[0][1])
-
-    def test_raises_when_all_streams_inaccessible(self):
-        """Raises ActiveCampaignDiscoveryForbiddenError when no streams are accessible."""
-        client = _make_client(side_effect=ActiveCampaignForbiddenError('403'))
-        # Only parent streams in schemas (no children that could survive)
-        schemas_parents = {
-            'stream_a': SCHEMAS['stream_a'],
-            'stream_b': SCHEMAS['stream_b'],
+        """Child stream is pruned from schemas when its parent is inaccessible."""
+        mock_streams = {
+            'stream_a': _make_stream_cls(parent=None, accessible=False),
+            'stream_b': _make_stream_cls(parent=None, accessible=True),
+            'child_of_a': _make_stream_cls(parent='stream_a', accessible=True),
         }
-        flat_parents = {
-            'stream_a': FLAT_STREAMS['stream_a'],
-            'stream_b': FLAT_STREAMS['stream_b'],
+        schemas = {'stream_a': {}, 'stream_b': {}, 'child_of_a': {}}
+        field_metadata = {'stream_a': [], 'stream_b': [], 'child_of_a': []}
+        with patch('tap_activecampaign.discover.STREAMS', mock_streams):
+            _apply_access_checks(_make_client(), schemas, field_metadata)
+        self.assertNotIn('stream_a', schemas)
+        self.assertNotIn('child_of_a', schemas)
+        self.assertIn('stream_b', schemas)
+
+    def test_schemas_mutated_in_place(self):
+        """Return value is None; the same dict object is mutated (not replaced)."""
+        mock_streams = {
+            'stream_a': _make_stream_cls(parent=None, accessible=False),
+            'stream_b': _make_stream_cls(parent=None, accessible=True),
         }
-        with self.assertRaises(ActiveCampaignDiscoveryForbiddenError):
-            _get_accessible_streams(client, schemas_parents, flat_parents)
+        schemas, field_metadata = self._schemas_and_meta(['stream_a', 'stream_b'])
+        original_id = id(schemas)
+        with patch('tap_activecampaign.discover.STREAMS', mock_streams):
+            result = _apply_access_checks(_make_client(), schemas, field_metadata)
+        self.assertIsNone(result)
+        self.assertEqual(id(schemas), original_id)
+        self.assertNotIn('stream_a', schemas)
+        self.assertIn('stream_b', schemas)
+
+    def test_warning_logged_for_inaccessible_stream(self):
+        """A WARNING listing inaccessible streams is emitted when some are excluded."""
+        mock_streams = {
+            'stream_a': _make_stream_cls(parent=None, accessible=False),
+            'stream_b': _make_stream_cls(parent=None, accessible=True),
+        }
+        schemas, field_metadata = self._schemas_and_meta(['stream_a', 'stream_b'])
+        with patch('tap_activecampaign.discover.STREAMS', mock_streams):
+            with patch('tap_activecampaign.discover.LOGGER') as mock_logger:
+                _apply_access_checks(_make_client(), schemas, field_metadata)
+                warning_messages = [str(c) for c in mock_logger.warning.call_args_list]
+                self.assertTrue(any('stream_a' in m for m in warning_messages))
 
 
 # ---------------------------------------------------------------------------
 # TestDiscover
 # ---------------------------------------------------------------------------
 
-# Minimal schema returned by get_schemas() for discover() tests
 _MINIMAL_SCHEMA_DICT = {'type': 'object', 'properties': {'id': {'type': 'integer'}}}
-_MINIMAL_SCHEMAS = {'contacts': _MINIMAL_SCHEMA_DICT}
-_MINIMAL_FIELD_METADATA = {'contacts': []}
 _MINIMAL_FLAT_STREAMS = {'contacts': {'key_properties': ['id'], 'parent_tap_stream_id': None}}
 
 
@@ -177,34 +264,47 @@ class TestDiscover(unittest.TestCase):
 
     @patch('tap_activecampaign.discover.flatten_streams', return_value=_MINIMAL_FLAT_STREAMS)
     @patch('tap_activecampaign.discover.get_schemas',
-           return_value=(_MINIMAL_SCHEMAS, _MINIMAL_FIELD_METADATA))
-    def test_discover_with_client_calls_get_accessible_streams(self, mock_schemas, mock_flat):
-        """When a client is provided, _get_accessible_streams is called."""
-        client = _make_client()
-        with patch('tap_activecampaign.discover._get_accessible_streams',
-                   return_value=_MINIMAL_SCHEMAS) as mock_access:
-            discover(client=client)
-            mock_access.assert_called_once_with(client, _MINIMAL_SCHEMAS, _MINIMAL_FLAT_STREAMS)
-
-    @patch('tap_activecampaign.discover.STREAMS',
-           {'contacts': _make_stream_cls('contacts')})
-    @patch('tap_activecampaign.discover.flatten_streams', return_value=_MINIMAL_FLAT_STREAMS)
-    @patch('tap_activecampaign.discover.get_schemas',
-           return_value=(_MINIMAL_SCHEMAS, _MINIMAL_FIELD_METADATA))
-    def test_discover_with_client_accessible_stream_in_catalog(self, mock_schemas, mock_flat):
-        """Accessible stream appears in catalog when client is provided."""
-        client = _make_client(return_value={})
-        catalog = discover(client=client)
+           return_value=({'contacts': _MINIMAL_SCHEMA_DICT}, {'contacts': []}))
+    @patch('tap_activecampaign.discover._apply_access_checks')
+    def test_accessible_stream_appears_in_catalog(self, mock_access, mock_schemas, mock_flat):
+        """Stream not popped by _apply_access_checks appears in catalog."""
+        # _apply_access_checks is a no-op: schemas unchanged
+        catalog = discover(client=_make_client())
         stream_ids = [s.tap_stream_id for s in catalog.streams]
         self.assertIn('contacts', stream_ids)
 
-    @patch('tap_activecampaign.discover.STREAMS',
-           {'contacts': _make_stream_cls('contacts')})
     @patch('tap_activecampaign.discover.flatten_streams', return_value=_MINIMAL_FLAT_STREAMS)
     @patch('tap_activecampaign.discover.get_schemas',
-           return_value=(_MINIMAL_SCHEMAS, _MINIMAL_FIELD_METADATA))
-    def test_discover_with_client_inaccessible_stream_raises(self, mock_schemas, mock_flat):
-        """Raises ActiveCampaignDiscoveryForbiddenError when the only stream is inaccessible."""
-        client = _make_client(side_effect=ActiveCampaignForbiddenError('403'))
-        with self.assertRaises(ActiveCampaignDiscoveryForbiddenError):
+           return_value=({'contacts': _MINIMAL_SCHEMA_DICT}, {'contacts': []}))
+    def test_inaccessible_stream_excluded_from_catalog(self, mock_schemas, mock_flat):
+        """Stream popped by _apply_access_checks is excluded from catalog."""
+        def pop_contacts(client, schemas, field_metadata):
+            schemas.pop('contacts', None)
+            field_metadata.pop('contacts', None)
+        with patch('tap_activecampaign.discover._apply_access_checks', side_effect=pop_contacts):
+            catalog = discover(client=_make_client())
+        stream_ids = [s.tap_stream_id for s in catalog.streams]
+        self.assertNotIn('contacts', stream_ids)
+
+    @patch('tap_activecampaign.discover.flatten_streams', return_value=_MINIMAL_FLAT_STREAMS)
+    @patch('tap_activecampaign.discover.get_schemas',
+           return_value=({'contacts': _MINIMAL_SCHEMA_DICT}, {'contacts': []}))
+    def test_all_inaccessible_raises(self, mock_schemas, mock_flat):
+        """Raises ActiveCampaignDiscoveryForbiddenError propagated from _apply_access_checks."""
+        with patch('tap_activecampaign.discover._apply_access_checks',
+                   side_effect=ActiveCampaignDiscoveryForbiddenError('no access')):
+            with self.assertRaises(ActiveCampaignDiscoveryForbiddenError):
+                discover(client=_make_client())
+
+    @patch('tap_activecampaign.discover.flatten_streams', return_value=_MINIMAL_FLAT_STREAMS)
+    @patch('tap_activecampaign.discover.get_schemas',
+           return_value=({'contacts': _MINIMAL_SCHEMA_DICT}, {'contacts': []}))
+    def test_apply_access_checks_called_with_client_schemas_and_metadata(self, mock_schemas, mock_flat):
+        """discover() calls _apply_access_checks(client, schemas, field_metadata)."""
+        client = _make_client()
+        with patch('tap_activecampaign.discover._apply_access_checks') as mock_access:
             discover(client=client)
+            args = mock_access.call_args[0]
+            self.assertIs(args[0], client)
+            self.assertIsInstance(args[1], dict)
+            self.assertIsInstance(args[2], dict)

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,0 +1,213 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from tap_activecampaign.client import ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError
+from tap_activecampaign.discover import (
+    check_stream_access,
+    _get_accessible_streams,
+    discover,
+    ActiveCampaignDiscoveryForbiddenError,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(side_effect=None, return_value=None):
+    """Return a MagicMock client whose .get() behaves as requested."""
+    client = MagicMock()
+    if side_effect is not None:
+        client.get.side_effect = side_effect
+    elif return_value is not None:
+        client.get.return_value = return_value
+    else:
+        client.get.return_value = {}
+    return client
+
+
+def _make_stream_cls(path):
+    """Return a minimal mock stream class with a path attribute."""
+    cls = MagicMock()
+    cls.path = path
+    return cls
+
+
+# ---------------------------------------------------------------------------
+# TestCheckStreamAccess
+# ---------------------------------------------------------------------------
+
+class TestCheckStreamAccess(unittest.TestCase):
+    """Unit tests for check_stream_access()."""
+
+    def test_returns_true_when_accessible(self):
+        """A successful GET returns True."""
+        client = _make_client(return_value={'contacts': []})
+        result = check_stream_access(client, 'contacts', 'contacts')
+        self.assertTrue(result)
+        client.get.assert_called_once_with(path='contacts', params='limit=1', endpoint='contacts')
+
+    def test_returns_false_on_forbidden_error(self):
+        """A 403 ForbiddenError returns False without re-raising."""
+        client = _make_client(side_effect=ActiveCampaignForbiddenError('403 Forbidden'))
+        result = check_stream_access(client, 'contacts', 'contacts')
+        self.assertFalse(result)
+
+    def test_returns_false_on_unauthorized_error(self):
+        """A 401 UnauthorizedError returns False without re-raising."""
+        client = _make_client(side_effect=ActiveCampaignUnauthorizedError('401 Unauthorized'))
+        result = check_stream_access(client, 'contacts', 'contacts')
+        self.assertFalse(result)
+
+    def test_reraises_unexpected_exception(self):
+        """Any other exception is re-raised to the caller."""
+        client = _make_client(side_effect=RuntimeError('unexpected'))
+        with self.assertRaises(RuntimeError):
+            check_stream_access(client, 'contacts', 'contacts')
+
+
+# ---------------------------------------------------------------------------
+# TestGetAccessibleStreams
+# ---------------------------------------------------------------------------
+
+# Minimal schema fixture: two parent streams + one child stream
+SCHEMAS = {
+    'stream_a': {'type': 'object', 'properties': {}},
+    'stream_b': {'type': 'object', 'properties': {}},
+    'child_of_a': {'type': 'object', 'properties': {}},
+}
+
+FLAT_STREAMS = {
+    'stream_a':   {'key_properties': ['id'], 'parent_tap_stream_id': None},
+    'stream_b':   {'key_properties': ['id'], 'parent_tap_stream_id': None},
+    'child_of_a': {'key_properties': ['id'], 'parent_tap_stream_id': 'stream_a'},
+}
+
+MOCK_STREAMS = {
+    'stream_a':   _make_stream_cls('path/a'),
+    'stream_b':   _make_stream_cls('path/b'),
+    'child_of_a': _make_stream_cls('path/a/{}/child'),
+}
+
+
+@patch('tap_activecampaign.discover.STREAMS', MOCK_STREAMS)
+class TestGetAccessibleStreams(unittest.TestCase):
+    """Unit tests for _get_accessible_streams()."""
+
+    def test_all_parent_streams_accessible(self):
+        """Returns all schemas (including child) when all parent streams are accessible."""
+        client = _make_client(return_value={})
+        result = _get_accessible_streams(client, SCHEMAS, FLAT_STREAMS)
+        self.assertEqual(set(result.keys()), {'stream_a', 'stream_b', 'child_of_a'})
+
+    def test_child_stream_not_probed(self):
+        """Child streams are skipped during probing (their path requires a parent id)."""
+        client = _make_client(return_value={})
+        _get_accessible_streams(client, SCHEMAS, FLAT_STREAMS)
+        probe_paths = [c.kwargs.get('path') or c.args[0] for c in client.get.call_args_list]
+        self.assertNotIn('path/a/{}/child', probe_paths)
+
+    def test_inaccessible_parent_excluded_from_catalog(self):
+        """An inaccessible parent stream is removed from the returned schemas."""
+        def selective_forbidden(path, **kwargs):
+            if path == 'path/b':
+                raise ActiveCampaignForbiddenError('403')
+            return {}
+        client = _make_client(side_effect=selective_forbidden)
+        result = _get_accessible_streams(client, SCHEMAS, FLAT_STREAMS)
+        self.assertNotIn('stream_b', result)
+        self.assertIn('stream_a', result)
+
+    def test_child_excluded_when_parent_inaccessible(self):
+        """Child stream is excluded when its parent is inaccessible."""
+        def block_stream_a(path, **kwargs):
+            if path == 'path/a':
+                raise ActiveCampaignForbiddenError('403')
+            return {}
+        client = _make_client(side_effect=block_stream_a)
+        result = _get_accessible_streams(client, SCHEMAS, FLAT_STREAMS)
+        self.assertNotIn('stream_a', result)
+        self.assertNotIn('child_of_a', result)
+        self.assertIn('stream_b', result)
+
+    def test_warning_logged_for_inaccessible_streams(self):
+        """A warning is logged listing the inaccessible streams."""
+        client = _make_client(side_effect=ActiveCampaignForbiddenError('403'))
+        # stream_b is the only accessible one; stream_a blocked → that means all are blocked
+        # Use only stream_b accessible to verify warning content
+        schemas_two = {'stream_a': SCHEMAS['stream_a'], 'stream_b': SCHEMAS['stream_b']}
+        flat_two = {'stream_a': FLAT_STREAMS['stream_a'], 'stream_b': FLAT_STREAMS['stream_b']}
+
+        def block_a_only(path, **kwargs):
+            if path == 'path/a':
+                raise ActiveCampaignForbiddenError('403')
+            return {}
+
+        client = _make_client(side_effect=block_a_only)
+        with patch('tap_activecampaign.discover.LOGGER') as mock_logger:
+            _get_accessible_streams(client, schemas_two, flat_two)
+            warning_call = mock_logger.warning.call_args
+            self.assertIn('stream_a', warning_call[0][1])
+
+    def test_raises_when_all_streams_inaccessible(self):
+        """Raises ActiveCampaignDiscoveryForbiddenError when no streams are accessible."""
+        client = _make_client(side_effect=ActiveCampaignForbiddenError('403'))
+        # Only parent streams in schemas (no children that could survive)
+        schemas_parents = {
+            'stream_a': SCHEMAS['stream_a'],
+            'stream_b': SCHEMAS['stream_b'],
+        }
+        flat_parents = {
+            'stream_a': FLAT_STREAMS['stream_a'],
+            'stream_b': FLAT_STREAMS['stream_b'],
+        }
+        with self.assertRaises(ActiveCampaignDiscoveryForbiddenError):
+            _get_accessible_streams(client, schemas_parents, flat_parents)
+
+
+# ---------------------------------------------------------------------------
+# TestDiscover
+# ---------------------------------------------------------------------------
+
+# Minimal schema returned by get_schemas() for discover() tests
+_MINIMAL_SCHEMA_DICT = {'type': 'object', 'properties': {'id': {'type': 'integer'}}}
+_MINIMAL_SCHEMAS = {'contacts': _MINIMAL_SCHEMA_DICT}
+_MINIMAL_FIELD_METADATA = {'contacts': []}
+_MINIMAL_FLAT_STREAMS = {'contacts': {'key_properties': ['id'], 'parent_tap_stream_id': None}}
+
+
+class TestDiscover(unittest.TestCase):
+    """Unit tests for discover()."""
+
+    @patch('tap_activecampaign.discover.flatten_streams', return_value=_MINIMAL_FLAT_STREAMS)
+    @patch('tap_activecampaign.discover.get_schemas',
+           return_value=(_MINIMAL_SCHEMAS, _MINIMAL_FIELD_METADATA))
+    def test_discover_with_client_calls_get_accessible_streams(self, mock_schemas, mock_flat):
+        """When a client is provided, _get_accessible_streams is called."""
+        client = _make_client()
+        with patch('tap_activecampaign.discover._get_accessible_streams',
+                   return_value=_MINIMAL_SCHEMAS) as mock_access:
+            discover(client=client)
+            mock_access.assert_called_once_with(client, _MINIMAL_SCHEMAS, _MINIMAL_FLAT_STREAMS)
+
+    @patch('tap_activecampaign.discover.STREAMS',
+           {'contacts': _make_stream_cls('contacts')})
+    @patch('tap_activecampaign.discover.flatten_streams', return_value=_MINIMAL_FLAT_STREAMS)
+    @patch('tap_activecampaign.discover.get_schemas',
+           return_value=(_MINIMAL_SCHEMAS, _MINIMAL_FIELD_METADATA))
+    def test_discover_with_client_accessible_stream_in_catalog(self, mock_schemas, mock_flat):
+        """Accessible stream appears in catalog when client is provided."""
+        client = _make_client(return_value={})
+        catalog = discover(client=client)
+        stream_ids = [s.tap_stream_id for s in catalog.streams]
+        self.assertIn('contacts', stream_ids)
+
+    @patch('tap_activecampaign.discover.STREAMS',
+           {'contacts': _make_stream_cls('contacts')})
+    @patch('tap_activecampaign.discover.flatten_streams', return_value=_MINIMAL_FLAT_STREAMS)
+    @patch('tap_activecampaign.discover.get_schemas',
+           return_value=(_MINIMAL_SCHEMAS, _MINIMAL_FIELD_METADATA))
+    def test_discover_with_client_inaccessible_stream_raises(self, mock_schemas, mock_flat):
+        """Raises ActiveCampaignDiscoveryForbiddenError when the only stream is inaccessible."""
+        client = _make_client(side_effect=ActiveCampaignForbiddenError('403'))
+        with self.assertRaises(ActiveCampaignDiscoveryForbiddenError):
+            discover(client=client)

--- a/tests/unittests/test_discover.py
+++ b/tests/unittests/test_discover.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest.mock import MagicMock, patch
-from tap_activecampaign.client import ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError
+from tap_activecampaign.exceptions import ActiveCampaignForbiddenError, ActiveCampaignUnauthorizedError
 from tap_activecampaign.discover import (
     check_stream_access,
     _get_accessible_streams,
@@ -44,7 +44,7 @@ class TestCheckStreamAccess(unittest.TestCase):
         client = _make_client(return_value={'contacts': []})
         result = check_stream_access(client, 'contacts', 'contacts')
         self.assertTrue(result)
-        client.get.assert_called_once_with(path='contacts', params='limit=1', endpoint='contacts')
+        client.get.assert_called_once_with(path='contacts', params={'limit': 1}, endpoint='contacts')
 
     def test_returns_false_on_forbidden_error(self):
         """A 403 ForbiddenError returns False without re-raising."""
@@ -131,9 +131,6 @@ class TestGetAccessibleStreams(unittest.TestCase):
 
     def test_warning_logged_for_inaccessible_streams(self):
         """A warning is logged listing the inaccessible streams."""
-        client = _make_client(side_effect=ActiveCampaignForbiddenError('403'))
-        # stream_b is the only accessible one; stream_a blocked → that means all are blocked
-        # Use only stream_b accessible to verify warning content
         schemas_two = {'stream_a': SCHEMAS['stream_a'], 'stream_b': SCHEMAS['stream_b']}
         flat_two = {'stream_a': FLAT_STREAMS['stream_a'], 'stream_b': FLAT_STREAMS['stream_b']}
 


### PR DESCRIPTION
# Description of change

This PR updates the tap’s discovery flow to proactively probe stream endpoints and exclude streams that the provided ActiveCampaign credentials cannot access, preventing unauthorized streams from appearing in the generated catalog.

**Changes:**
- Add discovery-time probing of stream endpoints and filter inaccessible streams (and their children) out of the catalog.
- Add unit tests covering stream-access probing, filtering behavior, and discovery integration.
- Update the CLI discover path to pass the initialized client into `discover()`.

Jira: [SAC-30992](https://qlik-dev.atlassian.net/browse/SAC-30992)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
