### PR TITLE
Mark email_activities as full table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.0
+  * Mark email_activities as FULL_TABLE stream [#57](https://github.com/singer-io/tap-activecampaign/pull/57)
+
 ## 1.5.0
   * Exclude streams with unauthorized access from catalog during discovery [#55](https://github.com/singer-io/tap-activecampaign/pull/55)
   * Upgrade backoff lib version to 2.2.1, requests to 2.34.2, singer-python to 6.8.0

--- a/README.md
+++ b/README.md
@@ -210,7 +210,12 @@ This tap:
   - Bookmark: mdate
 - Transformations: camelCase to snake_case, remove links node
 
-
+[email_activities](https://developers.activecampaign.com/reference/list-all-email-activities)
+- Endpoint: https://{subdomain}.api-us1.com/emailActivities
+- Data key: emailActivities
+- Primary keys: id
+- Replication strategy: Full Table
+- Transformations: camelCase to snake_case, remove links node
 
 ## Authentication
 
@@ -277,7 +282,6 @@ This tap:
           "messages": "2020-07-22T19:12:02.000000Z",
           "contact_custom_field_values": "2020-06-08T18:42:51.000000Z",
           "account_contacts": "2020-07-22T19:16:06.000000Z",
-          "email_activities": "2020-07-22T19:17:54.000000Z",
           "automations": "2020-07-22T19:17:23.000000Z",
           "campaign_links": "2020-07-22T14:12:24.000000Z",
           "automation_blocks": "2020-07-22T19:48:41.000000Z",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-activecampaign',
-      version='1.5.0',
+      version='1.6.0',
       description='Singer.io tap for extracting data from the ActiveCampaign API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/state.json.example
+++ b/state.json.example
@@ -20,7 +20,6 @@
       "messages": "2020-07-22T19:12:02.000000Z",
       "contact_custom_field_values": "2020-06-08T18:42:51.000000Z",
       "account_contacts": "2020-07-22T19:16:06.000000Z",
-      "email_activities": "2020-07-22T19:17:54.000000Z",
       "automations": "2020-07-22T19:17:23.000000Z",
       "campaign_links": "2020-07-22T14:12:24.000000Z",
       "automation_blocks": "2020-07-22T19:48:41.000000Z",

--- a/tap_activecampaign/client.py
+++ b/tap_activecampaign/client.py
@@ -178,7 +178,7 @@ class ActiveCampaignClient(object):
         self.__user_agent = user_agent
         self.__session = requests.Session()
         self.__verified = False
-        self.base_url = '{}/api/{}/users/me'.format(self.__api_url, DEFAULT_API_VERSION)
+        self.base_url = '{}/api/{}/'.format(self.__api_url, DEFAULT_API_VERSION)
 
         if not is_api_url_valid(api_url):
             raise Exception('Error: api_url is not valid')
@@ -210,7 +210,7 @@ class ActiveCampaignClient(object):
             headers['User-Agent'] = self.__user_agent
         headers['Api-Token'] = self.__api_token
         headers['Accept'] = 'application/json'
-        url = self.base_url
+        url = self.base_url + 'users/me'
         response = self.__session.get(
             # Simple endpoint that returns 1 record w/ default organization URN
             url=url,

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -1011,7 +1011,7 @@ class EmailActivities(ActiveCampaign):
     Get data for email_activities. 
     """
     stream_name = 'email_activities'
-    replication_keys = ['tstamp']
+    replication_method = 'FULL_TABLE'
     path = 'emailActivities'
     data_key = 'emailActivities'
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -377,9 +377,8 @@ class ActiveCampaignTest(unittest.TestCase):
             },
             'email_activities': {
                 self.PRIMARY_KEYS: {'id'},
-                self.REPLICATION_METHOD: self.INCREMENTAL,
-                self.REPLICATION_KEYS: {'tstamp'},
-                self.OBEYS_START_DATE: True
+                self.REPLICATION_METHOD: self.FULL_TABLE,
+                self.OBEYS_START_DATE: False
             },
             'goals': {
                 self.PRIMARY_KEYS: {'id'},


### PR DESCRIPTION
# Description of change
**Mark email_activities as full table**

We have observed that [email_activities](https://developers.activecampaign.com/reference/list-all-email-activities) returns records in inconsistent manner. Find below example case for observation,

```
June 16, endpoint itself returned 239 records only even though there were more records. The most recent record had a timestamp of June 16 and that’s why it already write 16 June as bookmark. 

Then the same endpoint returned  261 records on June 18 and 263 records on 19 June. However, many of the new records have timestamps from June 8 and June 10, which are dates that were already in the past when we made first call on June 16. This means records from June 8 and June 10 were not returned in  June 16 API call, but appeared later in my June 18 and June 20 call. But, those records did not get synced because bookmark already advanced to 16 June.

```

When I checked with their AI Agent chatbot, It said that ActiveCampaign doesn’t document that the unfiltered list is a complete, point-in-time export, or that it’s ordered/consistent by tstamp. So it can behave like a “rolling feed”, where older items can appear later.Even in their API documentation they have mentioned similar like this.


<img width="502" height="185" alt="Screenshot 2026-06-26 at 3 51 16 PM" src="https://github.com/user-attachments/assets/7d32b03a-87e7-4a88-bf17-738fc03aae5b" />


<img width="801" height="299" alt="Screenshot 2026-06-26 at 3 54 55 PM" src="https://github.com/user-attachments/assets/c2362765-7c51-4291-8c0e-29bc8de221bf" />


Due to this inconsistency of endpoint, I believe we should mark this email_activities table as FULL_TABLE stream. It will fetch all records in every sync.



# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
